### PR TITLE
Reader & sources: upvotes-source link, reversible read rail, conference badges

### DIFF
--- a/components/FeedTabs.tsx
+++ b/components/FeedTabs.tsx
@@ -7,13 +7,15 @@ const LABELS: Record<FeedTab, string> = {
   famous: "Famous",
 };
 
-const HINTS: Record<FeedTab, string> = {
-  latest: "freshest arXiv submissions",
-  trending: "ranked by community upvotes",
-  famous: "ranked by citations",
+const HINTS: Record<FeedTab, { text: string; href?: string }> = {
+  latest: { text: "freshest arXiv submissions" },
+  trending: { text: "ranked by community upvotes", href: "https://huggingface.co/papers" },
+  famous: { text: "ranked by citations" },
 };
 
 export function FeedTabs({ active }: { active: FeedTab }) {
+  const hint = HINTS[active];
+  const hintClass = "ml-auto hidden font-mono text-[11px] text-faint min-[540px]:inline";
   return (
     <nav className="flex items-baseline gap-6 border-b border-line">
       {FEED_TABS.map((tab) => {
@@ -33,9 +35,18 @@ export function FeedTabs({ active }: { active: FeedTab }) {
           </Link>
         );
       })}
-      <span className="ml-auto hidden font-mono text-[11px] text-faint min-[540px]:inline">
-        {HINTS[active]}
-      </span>
+      {hint.href ? (
+        <a
+          href={hint.href}
+          target="_blank"
+          rel="noreferrer"
+          className={`${hintClass} transition-colors hover:text-muted-foreground hover:underline`}
+        >
+          {hint.text}
+        </a>
+      ) : (
+        <span className={hintClass}>{hint.text}</span>
+      )}
     </nav>
   );
 }

--- a/components/HtmlReader.tsx
+++ b/components/HtmlReader.tsx
@@ -21,7 +21,7 @@ export function HtmlReader({
   initialProgress: ProgressRow | null;
 }) {
   const containerRef = useRef<HTMLDivElement>(null);
-  // Read depth = deepest scroll fraction reached. Monotonic: it only grows.
+  // Read depth = current scroll fraction (viewport bottom). Reversible: scrolling up lowers it.
   const [readPct, setReadPct] = useState(clamp01(initialProgress?.readPct ?? 0));
   const readPctRef = useRef(readPct);
   const saveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -87,7 +87,7 @@ export function HtmlReader({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  // Track deepest scroll + debounce persistence.
+  // Track the current read depth (reversible) + debounce persistence.
   useEffect(() => {
     function onScroll() {
       const frac = readDepthFraction(
@@ -95,10 +95,8 @@ export function HtmlReader({
         window.innerHeight,
         document.documentElement.scrollHeight,
       );
-      if (frac > readPctRef.current) {
-        readPctRef.current = frac;
-        setReadPct(frac);
-      }
+      readPctRef.current = frac;
+      setReadPct(frac);
       if (saveTimer.current) clearTimeout(saveTimer.current);
       saveTimer.current = setTimeout(() => persist(), 600);
     }
@@ -114,7 +112,7 @@ export function HtmlReader({
   return (
     <>
       <div className="relative">
-        {/* Read rail: amber bar in the left gutter, filled to the deepest scroll. */}
+        {/* Read rail: amber bar in the left gutter, filled to the current read depth. */}
         <div
           data-testid="read-rail"
           aria-hidden

--- a/components/PaperCard.tsx
+++ b/components/PaperCard.tsx
@@ -24,6 +24,11 @@ export function PaperCard({
     <article className="flex flex-col gap-1.5 border-b border-hairline py-5">
       <div className="flex items-baseline gap-3 font-mono text-[11.5px] tracking-wide">
         <span className="text-accent">{paper.categories.slice(0, 2).join(" · ") || "paper"}</span>
+        {paper.venue && (
+          <span className="rounded-sm bg-tint px-1.5 py-0.5 text-[10px] font-medium tracking-wide text-accent">
+            {paper.venue}
+          </span>
+        )}
         {date && <span className="text-faint">{date}</span>}
         <span className="ml-auto whitespace-nowrap text-faint">{signalLine(paper)}</span>
       </div>

--- a/docs/superpowers/plans/2026-06-14-reader-and-sources-improvements.md
+++ b/docs/superpowers/plans/2026-06-14-reader-and-sources-improvements.md
@@ -1,0 +1,757 @@
+# Reader & Sources Improvements Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Link the Trending feed hint to its Hugging Face source, make the HTML reader's read rail fully reversible (scrolling up un-marks), and pull NeurIPS/ICLR/ICML papers via Semantic Scholar with a per-card venue badge.
+
+**Architecture:** Three independent changes in an existing Next.js 16 / React 19 app with a Supabase-backed shared corpus and Vitest tests. (1) A copy/markup tweak in one server component. (2) A ~3-line behavior change in one client component plus doc/test updates — no schema or server-action change, since the `read_pct` column already exists and `persist()` already sends `status`. (3) A new source adapter following the existing `lib/sources/*` adapter pattern, an additive `venue` column, and a badge on the paper card.
+
+**Tech Stack:** Next.js 16.2.7, React 19, TypeScript, Supabase (Postgres), Vitest + Testing Library + jsdom, Tailwind v4.
+
+**Project conventions to honor:**
+- `AGENTS.md`: this is a modified Next.js — consult `node_modules/next/dist/docs/` before using any framework API. (This plan introduces **no new** Next.js APIs; all changes follow existing component patterns.)
+- Test runner: `pnpm test` (all), `pnpm vitest run <path>` (one file), `pnpm typecheck`.
+- Source adapters expose a pure `parse*`/helper (unit-tested with a fixture) and a thin `fetch*` wrapper (not unit-tested) — mirror that.
+- Commit after each task.
+
+---
+
+## File Structure
+
+**Feature 1 — upvotes link**
+- Modify: `components/FeedTabs.tsx` — `HINTS` becomes `{ text, href? }`; render an `<a>` for hints with an href.
+- Test: `tests/components/FeedTabs.test.tsx` (new).
+
+**Feature 2 — reversible read rail**
+- Modify: `components/HtmlReader.tsx:91-104` — scroll handler tracks current depth instead of the session max; update comments at `:24` and `:117`.
+- Modify: `lib/reader/readDepth.ts:1-10` — correct the "running max / only increases" doc comments.
+- Modify: `docs/superpowers/specs/2026-06-12-scroll-depth-read-rail-design.md` — mark the monotonic "no un-mark" decision as superseded.
+- Test: `tests/components/HtmlReader.test.tsx` — add a reversibility test.
+
+**Feature 3 — conference sources + venue badge**
+- Modify: `lib/types.ts` — add optional `venue` to `NormalizedPaper` and `PaperRow`; add `"conferences"` to `SourceId`.
+- Create: `lib/sources/conferences.ts` — `labelConference()` (pure) + `fetchConferences()` (thin fetch).
+- Modify: `lib/corpus/dedupe.ts:29-44` — carry `venue` through the merge.
+- Modify: `lib/corpus/upsert.ts:6-23` — map `venue` into the row.
+- Modify: `lib/sources/index.ts:1-34` — register the `conferences` source.
+- Create: `supabase/migrations/0005_papers_venue.sql` — `alter table papers add column venue`.
+- Modify: `components/PaperCard.tsx:24-29` — render a venue badge chip.
+- Tests: `tests/sources/conferences.test.ts` (new), `tests/corpus/dedupe.test.ts` (add cases), `tests/corpus/upsert` coverage via a new `tests/corpus/upsert.test.ts` (new), `tests/components/PaperCard.test.tsx` (add cases).
+
+---
+
+## Task 1: Link "ranked by community upvotes" → Hugging Face Papers
+
+**Files:**
+- Modify: `components/FeedTabs.tsx`
+- Test: `tests/components/FeedTabs.test.tsx` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/components/FeedTabs.test.tsx`:
+
+```tsx
+import { test, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { FeedTabs } from "@/components/FeedTabs";
+
+test("the Trending hint links to the Hugging Face papers page", () => {
+  render(<FeedTabs active="trending" />);
+  const link = screen.getByRole("link", { name: /ranked by community upvotes/i });
+  expect(link).toHaveAttribute("href", "https://huggingface.co/papers");
+  expect(link).toHaveAttribute("target", "_blank");
+  expect(link).toHaveAttribute("rel", "noreferrer");
+});
+
+test("non-trending hints are plain text, not links", () => {
+  render(<FeedTabs active="latest" />);
+  const hint = screen.getByText("freshest arXiv submissions");
+  expect(hint.closest("a")).toBeNull();
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm vitest run tests/components/FeedTabs.test.tsx`
+Expected: FAIL — first test errors because the hint is a `<span>`, not a `link` role.
+
+- [ ] **Step 3: Implement the change**
+
+Replace the `HINTS` constant and the trailing hint markup in `components/FeedTabs.tsx`.
+
+Change the constant (lines 10-14) to:
+
+```tsx
+const HINTS: Record<FeedTab, { text: string; href?: string }> = {
+  latest: { text: "freshest arXiv submissions" },
+  trending: { text: "ranked by community upvotes", href: "https://huggingface.co/papers" },
+  famous: { text: "ranked by citations" },
+};
+```
+
+In the component, compute the hint and render an anchor when it has an href. Replace the trailing `<span>` (lines 36-38) — and add the `hint`/`hintClass` locals just inside the function body before `return`:
+
+```tsx
+export function FeedTabs({ active }: { active: FeedTab }) {
+  const hint = HINTS[active];
+  const hintClass = "ml-auto hidden font-mono text-[11px] text-faint min-[540px]:inline";
+  return (
+    <nav className="flex items-baseline gap-6 border-b border-line">
+      {FEED_TABS.map((tab) => {
+        const isActive = tab === active;
+        return (
+          <Link
+            key={tab}
+            href={tab === "latest" ? "/" : `/?tab=${tab}`}
+            aria-current={isActive ? "page" : undefined}
+            className={`-mb-px border-b-2 px-px pb-[11px] pt-2 text-[14.5px] tracking-wide transition-colors ${
+              isActive
+                ? "border-accent font-semibold text-ink"
+                : "border-transparent font-normal text-muted-foreground hover:text-ink"
+            }`}
+          >
+            {LABELS[tab]}
+          </Link>
+        );
+      })}
+      {hint.href ? (
+        <a
+          href={hint.href}
+          target="_blank"
+          rel="noreferrer"
+          className={`${hintClass} transition-colors hover:text-muted-foreground hover:underline`}
+        >
+          {hint.text}
+        </a>
+      ) : (
+        <span className={hintClass}>{hint.text}</span>
+      )}
+    </nav>
+  );
+}
+```
+
+(Use a plain `<a>`, not `next/link` — this is an external URL.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm vitest run tests/components/FeedTabs.test.tsx`
+Expected: PASS (both tests).
+
+- [ ] **Step 5: Typecheck**
+
+Run: `pnpm typecheck`
+Expected: no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add components/FeedTabs.tsx tests/components/FeedTabs.test.tsx
+git commit -m "feat(feed): link the Trending 'community upvotes' hint to huggingface.co/papers"
+```
+
+---
+
+## Task 2: Make the read rail fully reversible
+
+**Files:**
+- Modify: `components/HtmlReader.tsx`
+- Modify: `lib/reader/readDepth.ts` (comments only)
+- Modify: `docs/superpowers/specs/2026-06-12-scroll-depth-read-rail-design.md` (note)
+- Test: `tests/components/HtmlReader.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/components/HtmlReader.test.tsx`. First add `fireEvent` to the import and a geometry helper near the top (after the existing `beforeEach`):
+
+```tsx
+import { render, screen, fireEvent } from "@testing-library/react";
+
+function setGeometry(scrollY: number, innerHeight: number, scrollHeight: number) {
+  Object.defineProperty(window, "scrollY", { value: scrollY, configurable: true });
+  Object.defineProperty(window, "innerHeight", { value: innerHeight, configurable: true });
+  Object.defineProperty(document.documentElement, "scrollHeight", {
+    value: scrollHeight,
+    configurable: true,
+  });
+}
+```
+
+Then add the test:
+
+```tsx
+test("the read rail follows current scroll depth and shrinks on scroll up", () => {
+  const { container } = renderReader(null);
+  const rail = () => container.querySelector<HTMLElement>('[data-testid="read-rail"]')!;
+
+  // Doc 1000px, viewport 200px. scrollY=300 => (300+200)/1000 = 0.5.
+  setGeometry(300, 200, 1000);
+  fireEvent.scroll(window);
+  expect(rail().style.height).toBe("50%");
+
+  // Scroll back up: scrollY=50 => (50+200)/1000 = 0.25. A monotonic rail would
+  // stay at 50%; the reversible rail drops to 25%.
+  setGeometry(50, 200, 1000);
+  fireEvent.scroll(window);
+  expect(rail().style.height).toBe("25%");
+});
+```
+
+(Depths 0.5 and 0.25 are chosen because `0.5*100` and `0.25*100` are exact in floating point, so the `style.height` string is clean.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm vitest run tests/components/HtmlReader.test.tsx`
+Expected: FAIL — the second assertion gets `"50%"` (monotonic max never decreases) instead of `"25%"`.
+
+- [ ] **Step 3: Implement the change**
+
+In `components/HtmlReader.tsx`, the scroll handler (lines 91-104) currently only bumps the value when it grows. Replace the `onScroll` body so it tracks the current fraction unconditionally:
+
+```tsx
+  // Track the current read depth (reversible) + debounce persistence.
+  useEffect(() => {
+    function onScroll() {
+      const frac = readDepthFraction(
+        window.scrollY,
+        window.innerHeight,
+        document.documentElement.scrollHeight,
+      );
+      readPctRef.current = frac;
+      setReadPct(frac);
+      if (saveTimer.current) clearTimeout(saveTimer.current);
+      saveTimer.current = setTimeout(() => persist(), 600);
+    }
+    window.addEventListener("scroll", onScroll, { passive: true });
+    return () => {
+      window.removeEventListener("scroll", onScroll);
+      if (saveTimer.current) clearTimeout(saveTimer.current);
+    };
+  }, [persist]);
+```
+
+Update the two now-inaccurate comments in the same file:
+- Line 24: change `// Read depth = deepest scroll fraction reached. Monotonic: it only grows.` to `// Read depth = current scroll fraction (viewport bottom). Reversible: scrolling up lowers it.`
+- Line 117: change `{/* Read rail: amber bar in the left gutter, filled to the deepest scroll. */}` to `{/* Read rail: amber bar in the left gutter, filled to the current read depth. */}`
+
+(`persist()` is unchanged: it still sends `readPct: readPctRef.current` and `status: isComplete(depth) ? "done" : "reading"`, so a lower depth now correctly persists `"reading"`.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm vitest run tests/components/HtmlReader.test.tsx`
+Expected: PASS (new test plus the four existing ones — seeding the rail from saved `readPct`, empty rail when unread, etc. are unaffected).
+
+- [ ] **Step 5: Correct the read-depth helper docs**
+
+In `lib/reader/readDepth.ts`, rewrite the file header (lines 1-7) and the `DONE_THRESHOLD` comment so they describe the reversible model. Replace lines 1-10 with:
+
+```ts
+/**
+ * Read-depth math, independent of the DOM so it can be unit tested.
+ *
+ * Read depth is the current viewport BOTTOM as a fraction (0–1) of the document
+ * height. The reader tracks this live value (it rises and falls with scrolling)
+ * to drive the left-margin "read" rail, so scrolling back up lowers the rail.
+ */
+
+/** At/above this fraction the paper counts as finished (status -> done). */
+export const DONE_THRESHOLD = 0.98;
+```
+
+(The `readDepthFraction` and `isComplete` function bodies are unchanged — they already compute the current fraction; only the prose was wrong.)
+
+- [ ] **Step 6: Supersede the monotonic decision in the old spec**
+
+In `docs/superpowers/specs/2026-06-12-scroll-depth-read-rail-design.md`, under the `### Accepted trade-off` heading (around line 33), insert this line directly under the heading, above the existing paragraph:
+
+```markdown
+> **Superseded 2026-06-14:** the read rail is now fully reversible — scrolling up
+> lowers the rail and can return a finished paper to `reading`. See
+> `2026-06-14-reader-and-sources-improvements-design.md` §2. The monotonic
+> "no un-mark" behavior described below no longer applies.
+```
+
+- [ ] **Step 7: Run the full reader test group + typecheck**
+
+Run: `pnpm vitest run tests/components/HtmlReader.test.tsx tests/reader/readDepth.test.ts && pnpm typecheck`
+Expected: PASS, no type errors.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add components/HtmlReader.tsx lib/reader/readDepth.ts tests/components/HtmlReader.test.tsx docs/superpowers/specs/2026-06-12-scroll-depth-read-rail-design.md
+git commit -m "feat(reader): make the read rail fully reversible (scroll-up un-marks)"
+```
+
+---
+
+## Task 3: Add the `venue` field to the data model
+
+**Files:**
+- Modify: `lib/types.ts`
+
+- [ ] **Step 1: Add optional `venue` to the types**
+
+In `lib/types.ts`:
+
+Add `"conferences"` to the `SourceId` union (lines 1-6):
+
+```ts
+export type SourceId =
+  | "arxiv"
+  | "huggingface"
+  | "paperswithcode"
+  | "semanticscholar"
+  | "googlescholar"
+  | "conferences";
+```
+
+Add an optional `venue` to `NormalizedPaper` (after `publishedAt`, around line 20):
+
+```ts
+  /** ISO 8601 string. */
+  publishedAt: string | null;
+  /** Short conference label, e.g. "NeurIPS 2024". Set only by the conferences source. */
+  venue?: string | null;
+  signals: PaperSignals;
+```
+
+Add an optional `venue` to `PaperRow` (after `published_at`, around line 42):
+
+```ts
+  published_at: string | null;
+  venue?: string | null;
+  hf_upvotes: number;
+```
+
+- [ ] **Step 2: Typecheck**
+
+Run: `pnpm typecheck`
+Expected: no errors (optional fields don't break the four existing parsers or any fixture).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add lib/types.ts
+git commit -m "feat(types): add optional venue to NormalizedPaper and PaperRow"
+```
+
+---
+
+## Task 4: Carry `venue` through dedup
+
+**Files:**
+- Modify: `lib/corpus/dedupe.ts`
+- Test: `tests/corpus/dedupe.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tests/corpus/dedupe.test.ts`:
+
+```ts
+test("an arxiv row inherits a conference venue when merged", () => {
+  const merged = dedupe([
+    base({ arxivId: "2401.9" }),
+    base({ arxivId: "2401.9", venue: "NeurIPS 2024" }),
+  ]);
+  expect(merged).toHaveLength(1);
+  expect(merged[0].venue).toBe("NeurIPS 2024");
+});
+
+test("venue survives regardless of merge order", () => {
+  const merged = dedupe([
+    base({ arxivId: "2401.10", venue: "ICML 2025" }),
+    base({ arxivId: "2401.10" }),
+  ]);
+  expect(merged[0].venue).toBe("ICML 2025");
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm vitest run tests/corpus/dedupe.test.ts`
+Expected: FAIL — "an arxiv row inherits a conference venue" gets `undefined` (the merge branch never copies `venue`).
+
+- [ ] **Step 3: Implement the change**
+
+In `lib/corpus/dedupe.ts`, the merge branch (lines 29-44) builds the merged object. Add a `venue` line alongside the other coalesced fields:
+
+```ts
+    map.set(key, {
+      ...cur,
+      arxivId: cur.arxivId ?? p.arxivId,
+      doi: cur.doi ?? p.doi,
+      abstract: cur.abstract ?? p.abstract,
+      htmlUrl: cur.htmlUrl ?? p.htmlUrl,
+      pdfUrl: cur.pdfUrl ?? p.pdfUrl,
+      sourceUrl: cur.sourceUrl ?? p.sourceUrl,
+      publishedAt: cur.publishedAt ?? p.publishedAt,
+      venue: cur.venue ?? p.venue,
+      categories: Array.from(new Set([...cur.categories, ...p.categories])),
+      signals: {
+        hfUpvotes: maxSignal(cur.signals.hfUpvotes, p.signals.hfUpvotes),
+        pwcStars: maxSignal(cur.signals.pwcStars, p.signals.pwcStars),
+        citations: maxSignal(cur.signals.citations, p.signals.citations),
+      },
+    });
+```
+
+(The first-insert branch at line 26 spreads `...p`, so it already preserves `venue`.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm vitest run tests/corpus/dedupe.test.ts`
+Expected: PASS (all, including the 5 existing cases).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/corpus/dedupe.ts tests/corpus/dedupe.test.ts
+git commit -m "feat(corpus): preserve venue when deduping papers across sources"
+```
+
+---
+
+## Task 5: The conferences source adapter
+
+**Files:**
+- Create: `lib/sources/conferences.ts`
+- Test: `tests/sources/conferences.test.ts` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/sources/conferences.test.ts`:
+
+```ts
+import { test, expect } from "vitest";
+import { labelConference } from "@/lib/sources/conferences";
+import type { NormalizedPaper } from "@/lib/types";
+
+const paper = (publishedAt: string | null): NormalizedPaper => ({
+  arxivId: "2401.1",
+  doi: null,
+  title: "T",
+  authors: [],
+  abstract: null,
+  categories: [],
+  htmlUrl: null,
+  pdfUrl: null,
+  sourceUrl: null,
+  publishedAt,
+  signals: { citations: 5 },
+});
+
+test("stamps a short venue label with the publication year", () => {
+  const [p] = labelConference([paper("2024-01-01T00:00:00Z")], "NeurIPS");
+  expect(p.venue).toBe("NeurIPS 2024");
+});
+
+test("falls back to the bare label when the year is unknown", () => {
+  const [p] = labelConference([paper(null)], "ICLR");
+  expect(p.venue).toBe("ICLR");
+});
+
+test("leaves the other fields intact", () => {
+  const [p] = labelConference([paper("2025-01-01T00:00:00Z")], "ICML");
+  expect(p.arxivId).toBe("2401.1");
+  expect(p.signals.citations).toBe(5);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm vitest run tests/sources/conferences.test.ts`
+Expected: FAIL — cannot import `labelConference` (module does not exist).
+
+- [ ] **Step 3: Implement the adapter**
+
+Create `lib/sources/conferences.ts`:
+
+```ts
+import { env } from "@/lib/env";
+import type { NormalizedPaper } from "@/lib/types";
+import { parseS2 } from "./semanticscholar";
+
+interface ConferenceVenue {
+  /** Short badge label. */
+  label: string;
+  /** Semantic Scholar canonical venue name used for the `venue` filter. */
+  s2Venue: string;
+}
+
+const VENUES: ConferenceVenue[] = [
+  { label: "NeurIPS", s2Venue: "Neural Information Processing Systems" },
+  { label: "ICML", s2Venue: "International Conference on Machine Learning" },
+  { label: "ICLR", s2Venue: "International Conference on Learning Representations" },
+];
+
+const FIELDS = "title,abstract,year,citationCount,authors,externalIds,openAccessPdf";
+
+/** Stamp a short venue label ("NeurIPS 2024") onto parsed papers. Pure + testable. */
+export function labelConference(papers: NormalizedPaper[], label: string): NormalizedPaper[] {
+  return papers.map((p) => {
+    const year = p.publishedAt ? p.publishedAt.slice(0, 4) : null;
+    return { ...p, venue: year ? `${label} ${year}` : label };
+  });
+}
+
+/** The last two calendar years, e.g. "2025-2026" — bounds conference volume. */
+function recentYears(now: Date = new Date()): string {
+  const y = now.getUTCFullYear();
+  return `${y - 1}-${y}`;
+}
+
+/**
+ * Pull recent papers from top ML conferences (NeurIPS / ICML / ICLR) via Semantic
+ * Scholar's venue filter. No API key required (rate-limited; a 429 skips that venue).
+ * Each paper is stamped with a short venue badge label.
+ */
+export async function fetchConferences(years: string = recentYears()): Promise<NormalizedPaper[]> {
+  const key = env().SEMANTIC_SCHOLAR_API_KEY;
+  const headers: Record<string, string> = { "User-Agent": "PaperDeck/1.0 (research reader)" };
+  if (key) headers["x-api-key"] = key;
+
+  const all: NormalizedPaper[] = [];
+  for (const v of VENUES) {
+    const url =
+      `https://api.semanticscholar.org/graph/v1/paper/search?query=${encodeURIComponent(v.label)}` +
+      `&venue=${encodeURIComponent(v.s2Venue)}&year=${years}&limit=50&fields=${FIELDS}`;
+    const res = await fetch(url, { headers });
+    if (!res.ok) {
+      if (res.status === 429) continue; // expected without a key — skip this venue
+      throw new Error(`conferences ${res.status}`);
+    }
+    all.push(...labelConference(parseS2(await res.json()), v.label));
+  }
+  return all;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm vitest run tests/sources/conferences.test.ts`
+Expected: PASS (all three).
+
+- [ ] **Step 5: Typecheck**
+
+Run: `pnpm typecheck`
+Expected: no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/sources/conferences.ts tests/sources/conferences.test.ts
+git commit -m "feat(sources): conference adapter (NeurIPS/ICLR/ICML via Semantic Scholar venue filter)"
+```
+
+> Note: `fetchConferences` is a thin fetch wrapper (not unit-tested, matching `fetchArxivLatest`/`fetchHfDaily`). The exact `venue`/`year` query params may need tuning against the live Semantic Scholar API during manual verification (Task 8); a venue returning nothing is non-fatal.
+
+---
+
+## Task 6: Map `venue` into the upserted row + register the source
+
+**Files:**
+- Modify: `lib/corpus/upsert.ts`
+- Modify: `lib/sources/index.ts`
+- Test: `tests/corpus/upsert.test.ts` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/corpus/upsert.test.ts` (covers only the pure `toPaperRow` mapping — no DB):
+
+```ts
+import { test, expect } from "vitest";
+import { toPaperRow } from "@/lib/corpus/upsert";
+import type { NormalizedPaper } from "@/lib/types";
+
+const base = (o: Partial<NormalizedPaper>): NormalizedPaper => ({
+  arxivId: "2401.1",
+  doi: null,
+  title: "T",
+  authors: [],
+  abstract: null,
+  categories: [],
+  htmlUrl: null,
+  pdfUrl: null,
+  sourceUrl: null,
+  publishedAt: null,
+  signals: {},
+  ...o,
+});
+
+test("maps a venue when present", () => {
+  expect(toPaperRow(base({ venue: "NeurIPS 2024" })).venue).toBe("NeurIPS 2024");
+});
+
+test("maps a missing venue to null", () => {
+  expect(toPaperRow(base({})).venue).toBeNull();
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm vitest run tests/corpus/upsert.test.ts`
+Expected: FAIL — `toPaperRow(...).venue` is `undefined` (the row object has no `venue` key).
+
+- [ ] **Step 3: Implement the mapping**
+
+In `lib/corpus/upsert.ts`, add a `venue` line to the returned row object in `toPaperRow` (after `published_at`, around line 17):
+
+```ts
+    source_url: p.sourceUrl,
+    published_at: p.publishedAt,
+    venue: p.venue ?? null,
+    hf_upvotes: p.signals.hfUpvotes ?? 0,
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm vitest run tests/corpus/upsert.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Register the conferences source**
+
+In `lib/sources/index.ts`, import the adapter (after line 7) and add a registry entry.
+
+Add the import:
+
+```ts
+import { fetchScholar } from "./googlescholar";
+import { fetchConferences } from "./conferences";
+```
+
+Add the registry entry to the array returned by `sources()` (after the `semanticscholar` entry, line 31):
+
+```ts
+    { id: "semanticscholar", enabled: true, run: () => fetchS2Famous() },
+    { id: "conferences", enabled: true, run: () => fetchConferences() },
+    { id: "googlescholar", enabled: Boolean(e.SERPAPI_KEY), run: () => fetchScholar() },
+```
+
+- [ ] **Step 6: Typecheck + run the corpus/sources test groups**
+
+Run: `pnpm vitest run tests/corpus tests/sources && pnpm typecheck`
+Expected: PASS, no type errors (existing `registry.test.ts` is unaffected — it uses inline fake sources).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add lib/corpus/upsert.ts lib/sources/index.ts tests/corpus/upsert.test.ts
+git commit -m "feat(corpus): persist venue and register the conferences source"
+```
+
+---
+
+## Task 7: Database migration + venue badge on the card
+
+**Files:**
+- Create: `supabase/migrations/0005_papers_venue.sql`
+- Modify: `components/PaperCard.tsx`
+- Test: `tests/components/PaperCard.test.tsx`
+
+- [ ] **Step 1: Create the migration**
+
+Create `supabase/migrations/0005_papers_venue.sql`:
+
+```sql
+-- Add a conference venue label (e.g. "NeurIPS 2024") to the shared corpus.
+-- Nullable and additive: populated by the conferences source and merged onto
+-- matching arXiv rows; existing rows stay NULL and backfill as the cron re-ingests.
+alter table papers add column if not exists venue text;
+```
+
+- [ ] **Step 2: Write the failing card tests**
+
+Add to `tests/components/PaperCard.test.tsx`:
+
+```tsx
+test("renders a venue badge when the paper has a venue", () => {
+  render(<PaperCard paper={{ ...paper, venue: "NeurIPS 2024" }} starred={false} />);
+  expect(screen.getByText("NeurIPS 2024")).toBeInTheDocument();
+});
+
+test("omits the venue badge when there is no venue", () => {
+  render(<PaperCard paper={paper} starred={false} />);
+  expect(screen.queryByText(/NeurIPS|ICML|ICLR/)).toBeNull();
+});
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `pnpm vitest run tests/components/PaperCard.test.tsx`
+Expected: FAIL — "renders a venue badge" cannot find the text (no badge yet).
+
+- [ ] **Step 4: Implement the badge**
+
+In `components/PaperCard.tsx`, add the badge in the top meta row, right after the category `<span>` (lines 25-29). The row becomes:
+
+```tsx
+      <div className="flex items-baseline gap-3 font-mono text-[11.5px] tracking-wide">
+        <span className="text-accent">{paper.categories.slice(0, 2).join(" · ") || "paper"}</span>
+        {paper.venue && (
+          <span className="rounded-sm bg-tint px-1.5 py-0.5 text-[10px] font-medium tracking-wide text-accent">
+            {paper.venue}
+          </span>
+        )}
+        {date && <span className="text-faint">{date}</span>}
+        <span className="ml-auto whitespace-nowrap text-faint">{signalLine(paper)}</span>
+      </div>
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `pnpm vitest run tests/components/PaperCard.test.tsx`
+Expected: PASS (all, including the 7 existing cases).
+
+- [ ] **Step 6: Typecheck**
+
+Run: `pnpm typecheck`
+Expected: no errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add supabase/migrations/0005_papers_venue.sql components/PaperCard.tsx tests/components/PaperCard.test.tsx
+git commit -m "feat(corpus): venue column + conference badge on the paper card"
+```
+
+---
+
+## Task 8: Full verification
+
+- [ ] **Step 1: Run the entire test suite**
+
+Run: `pnpm test`
+Expected: all tests PASS.
+
+- [ ] **Step 2: Typecheck + lint**
+
+Run: `pnpm typecheck && pnpm lint`
+Expected: no errors.
+
+- [ ] **Step 3: Apply the migration to Supabase**
+
+The `0005_papers_venue.sql` migration must be applied to the live project before the conferences source can write `venue` (the cron upsert will otherwise fail on the unknown column). Apply it via the Supabase CLI (`supabase db push`) or the Supabase MCP `apply_migration` tool. This is additive and safe (nullable column, `if not exists`).
+
+- [ ] **Step 4: Manual smoke test (optional but recommended)**
+
+Run `pnpm dev --webpack` (per the project's Turbopack caveat), then:
+- **Feed:** the Trending tab hint "ranked by community upvotes" is a link to `https://huggingface.co/papers`.
+- **Reader:** open an HTML paper, scroll down (rail fills), scroll back up (rail shrinks); scrolling above the end returns status to reading.
+- **Conferences:** trigger a refresh (owner "Refresh" button or `GET /api/cron/refresh` with `CRON_SECRET`); confirm some cards show a `NeurIPS/ICML/ICLR <year>` badge. If a venue returns nothing, tune the `venue`/`year` params in `lib/sources/conferences.ts` against the live Semantic Scholar API.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- §1 upvotes link → Task 1. ✓
+- §2 reversible rail (logic, helper docs, old-spec supersede, tests) → Task 2. ✓
+- §3 conferences: `venue` type → Task 3; dedup merge → Task 4; adapter + label stamping → Task 5; `toPaperRow` map + source registration → Task 6; migration + card badge → Task 7. ✓
+- §3 testing items (parse/label fixture, dedupe venue, toPaperRow, card badge) → Tasks 4–7. ✓
+
+**Deviation from spec (intentional, simpler):** the spec said `parseS2` would capture venue; instead `labelConference` stamps the short label from the query, leaving `parseS2` untouched (more robust — no dependency on S2's raw venue string). Outcome is identical: conference papers carry a `venue` badge.
+
+**Type consistency:** `venue` is `string | null` (optional) on `NormalizedPaper` and `PaperRow`; `labelConference(papers, label)` returns `NormalizedPaper[]`; `toPaperRow` writes `venue: p.venue ?? null`; dedupe merges `cur.venue ?? p.venue`; `SourceId` includes `"conferences"` and the registry entry uses that exact id. Consistent across tasks.
+
+**Placeholder scan:** none — every step has concrete code and an exact command.

--- a/docs/superpowers/specs/2026-06-12-scroll-depth-read-rail-design.md
+++ b/docs/superpowers/specs/2026-06-12-scroll-depth-read-rail-design.md
@@ -32,6 +32,11 @@ Replace block-based marking with an **automatic, scroll-position read rail**:
 
 ### Accepted trade-off
 
+> **Superseded 2026-06-14:** the read rail is now fully reversible — scrolling up
+> lowers the rail and can return a finished paper to `reading`. See
+> `2026-06-14-reader-and-sources-improvements-design.md` §2. The monotonic
+> "no un-mark" behavior described below no longer applies.
+
 Deepest-scroll tracking is monotonic and has **no un-mark**: scrolling (or
 flinging) to the bottom fills the rail to 100% permanently. This is inherent to
 the automatic model and was accepted during design.

--- a/docs/superpowers/specs/2026-06-12-scroll-depth-read-rail-design.md
+++ b/docs/superpowers/specs/2026-06-12-scroll-depth-read-rail-design.md
@@ -49,6 +49,8 @@ document height.
 - Definition: `readPct = max over the session of (scrollY + innerHeight) /
   documentHeight`, i.e. the deepest point that has reached the **bottom** of the
   viewport. Monotonic — only increases.
+
+> **Superseded 2026-06-14:** `readPct` is now the *current* viewport-bottom fraction (it rises and falls with scrolling), not a session max. See `2026-06-14-reader-and-sources-improvements-design.md` §2.
 - The client owns the max: it seeds from the saved `readPct` on mount and bumps
   it on scroll. The server stores whatever the client sends (no server-side max).
 - `readPct ≥ 0.98` ⇒ `status = 'done'` (bottom of the last screen reached), which

--- a/docs/superpowers/specs/2026-06-14-reader-and-sources-improvements-design.md
+++ b/docs/superpowers/specs/2026-06-14-reader-and-sources-improvements-design.md
@@ -1,0 +1,208 @@
+# Reader & sources improvements
+
+**Date:** 2026-06-14
+**Status:** Approved (design), pending spec review
+**Scope:** Three independent, small changes requested together:
+
+1. Link the "ranked by community upvotes" feed hint to its source (Hugging Face Papers).
+2. Make the HTML reader's read rail **fully reversible** (scrolling up un-marks), reversing the monotonic decision in the 2026-06-12 read-rail spec.
+3. Pull papers from top conferences (NeurIPS / ICLR / ICML) via Semantic Scholar, surfaced with a venue badge.
+
+Each section below stands on its own and can be implemented and shipped independently.
+
+---
+
+## 1. Link "ranked by community upvotes" → Hugging Face Papers
+
+### Problem
+The Trending feed is ranked by Hugging Face daily-papers upvotes (`hf_upvotes`, from
+`https://huggingface.co/api/daily_papers`), but the hint copy "ranked by community
+upvotes" (`components/FeedTabs.tsx:12`) gives no indication of where that signal
+comes from. Readers can't see the source.
+
+### Decision
+Make the **Trending** hint a link to `https://huggingface.co/papers` (the Hugging
+Face Daily Papers page the upvotes are sourced from). Latest and Famous hints stay
+plain text — only Trending gets a link, matching the request.
+
+### Implementation
+- `components/FeedTabs.tsx`: change `HINTS` from `Record<FeedTab, string>` to
+  `Record<FeedTab, { text: string; href?: string }>`:
+  - `latest: { text: "freshest arXiv submissions" }`
+  - `trending: { text: "ranked by community upvotes", href: "https://huggingface.co/papers" }`
+  - `famous: { text: "ranked by citations" }`
+- In the render, the trailing `<span>` keeps its `font-mono text-[11px] text-faint`
+  styling. When the active hint has an `href`, render an
+  `<a href={hint.href} target="_blank" rel="noreferrer">` with a subtle
+  underline-on-hover (e.g. `hover:text-muted-foreground hover:underline`); otherwise
+  render the text directly. No new dependencies.
+
+### Testing
+- Render `FeedTabs` with `active="trending"` → the hint is an anchor pointing at
+  `https://huggingface.co/papers` with `target="_blank"` and `rel="noreferrer"`.
+- Render with `active="latest"` / `active="famous"` → the hint is plain text, no anchor.
+
+---
+
+## 2. Fully reversible read rail
+
+### Problem
+The 2026-06-12 read-rail spec made read depth **monotonic** — a running session max
+that only ever increases (`HtmlReader.tsx`: `if (frac > readPctRef.current)`), with an
+explicitly "accepted trade-off" of **no un-mark**. In practice an accidental fling or
+momentum-scroll to the bottom permanently fills the rail to 100% and marks the paper
+`done`, with no way to undo it short of clearing progress. We are reversing that
+decision.
+
+### Decision
+Read depth tracks the **current** viewport-bottom position, not the session max:
+
+- Scrolling down grows the rail; scrolling up **shrinks** it.
+- `status` is derived from the current depth on every save, so scrolling back above
+  the `DONE_THRESHOLD` (0.98) returns the paper from `done` to `reading`.
+- This makes an accidental fling fully recoverable: scroll back up and the rail, the
+  "% read", and the `done` status all follow.
+
+### Accepted trade-off (chosen during design)
+Reversibility is symmetric: scrolling up to re-read an earlier section also lowers the
+rail and can flip a finished paper back to `reading` (it would reappear on the
+"Continue reading" shelf). This is acceptable and is the point — read state reflects
+*where you currently are*, not the deepest point ever touched.
+
+Opening a previously-finished paper is **not** affected: resume scrolls you to your
+saved position (near the bottom for a finished paper), so the first scroll event keeps
+it `done`. Only a deliberate scroll up un-marks it.
+
+### Model change
+The read-depth math (`lib/reader/readDepthFraction`) is **unchanged** — it already
+computes the current viewport-bottom fraction; the monotonic behavior lived only in the
+component. The change is to stop taking the max:
+
+- `components/HtmlReader.tsx`, scroll handler: replace
+  ```
+  if (frac > readPctRef.current) { readPctRef.current = frac; setReadPct(frac); }
+  ```
+  with an unconditional update:
+  ```
+  readPctRef.current = frac;
+  setReadPct(frac);
+  ```
+- `persist()` is otherwise unchanged: it still sends `readPct: readPctRef.current` and
+  `status: isComplete(depth) ? "done" : "reading"`. Because `depth` is now the current
+  fraction, `status` can move `done → reading`.
+- The left rail (`style={{ height: readPct% }}`), the top `ReaderProgressBar`
+  (`pct={readPct}`), and the card/shelf "% read" (`max(read_pct, scroll_pct)`) all read
+  the same value and become reversible automatically. No change needed to the shelf
+  query: for HTML rows `read_pct` (viewport bottom) ≥ `scroll_pct` (viewport top), so
+  `max(...)` still resolves to `read_pct`; PDF rows are untouched.
+
+### No schema change
+The `read_pct` column already exists (migration `0004`). We change only the value
+written, not the storage.
+
+### Docs to correct (truthfulness)
+- `lib/reader/readDepth.ts`: the file header and `DONE_THRESHOLD`/`readDepthFraction`
+  comments describe a "running max … only ever increases." Rewrite to describe the
+  current-depth (reversible) model.
+- `components/HtmlReader.tsx`: the `readPct` comment ("Monotonic: it only grows") and
+  the rail comment ("filled to the deepest scroll") must be updated.
+- `docs/superpowers/specs/2026-06-12-scroll-depth-read-rail-design.md`: mark the
+  "Accepted trade-off" (no un-mark) and the "Monotonic — only increases" lines in the
+  Model section as **superseded by this spec (2026-06-14)**, with a one-line pointer.
+  Leave the rest of that spec intact.
+
+### Testing
+- Update the `HtmlReader` jsdom test that asserts the rail only grows: it must now
+  assert that a smaller scroll fraction *lowers* `readPct` (rail shrinks on scroll up).
+- Assert a scroll to ≥ 0.98 then back above the threshold persists `status: "reading"`
+  on the later save (done un-marks).
+- `readDepthFraction` unit tests are unchanged (pure function, same behavior).
+
+---
+
+## 3. Conference sources (NeurIPS / ICLR / ICML) + venue badge
+
+### Problem
+The corpus pulls from arXiv, Hugging Face, and Semantic Scholar, but nothing surfaces
+*peer-reviewed acceptance at top venues*. Readers asked to pull from NeurIPS, ICLR, and
+ICML. Google Scholar is already wired but gated behind a paid SerpAPI key and largely
+redundant with the free Semantic Scholar citations, so it is not the right vehicle.
+
+### Decision
+Add a free, key-less conference source backed by **Semantic Scholar's venue filter**,
+and thread a `venue` field through the pipeline so conference papers carry a visible
+badge. Because most conference papers also have an arXiv preprint, dedup merges them
+into existing arXiv rows — so papers already in the corpus light up with an acceptance
+badge (e.g. "NeurIPS 2024").
+
+### New source adapter
+`lib/sources/conferences.ts` → `fetchConferences()`:
+
+- Target venues (short label ↔ Semantic Scholar canonical name):
+  - `NeurIPS` ↔ "Neural Information Processing Systems"
+  - `ICML` ↔ "International Conference on Machine Learning"
+  - `ICLR` ↔ "International Conference on Learning Representations"
+- For each venue, call the existing S2 search endpoint
+  (`https://api.semanticscholar.org/graph/v1/paper/search`) with the `venue` filter and
+  a recent `year` range (default: current year and the prior year — bounded to keep
+  volume sane), reusing the same headers/`x-api-key`-if-present and **429-tolerant skip**
+  as `fetchS2Famous`. No API key required.
+- Fields requested add `venue` (and `publicationVenue`) to the existing field set.
+- Each parsed paper is stamped `venue: "<shortLabel> <year>"` (e.g. `"NeurIPS 2024"`)
+  using the short label of the venue that produced it plus the paper's `year`. Stamping
+  from the query (not from S2's raw venue string) avoids fragile venue-name
+  normalization. If `year` is missing, use just the short label.
+- Registered in `lib/sources/index.ts` as
+  `{ id: "conferences", enabled: true, run: () => fetchConferences() }`, with
+  `"conferences"` added to the `SourceId` union in `lib/types.ts`.
+
+> Note: exact S2 venue-string matching can be finicky. The adapter test uses a recorded
+> fixture to lock parsing; the live `venue`/`year` query params will be tuned against the
+> real API during implementation. A venue that returns nothing is non-fatal (empty array,
+> same as a 429 skip).
+
+### `venue` field threaded through the pipeline
+- `lib/types.ts`: add `venue: string | null` to `NormalizedPaper` and
+  `venue: string | null` to `PaperRow`.
+- `lib/sources/semanticscholar.ts` (`parseS2`): capture `venue` from the S2 response
+  when present (used by `fetchConferences`; the existing `fetchS2Famous` may also gain a
+  venue when S2 returns one — harmless). `S2Paper` gains `venue?` / `publicationVenue?`.
+- `lib/corpus/dedupe.ts`: when merging, `venue: cur.venue ?? p.venue` so a non-null
+  conference venue is preserved onto a merged arXiv row regardless of source order.
+- `lib/corpus/upsert.ts` (`toPaperRow`): map `venue: p.venue ?? null`.
+- Migration `supabase/migrations/0005_papers_venue.sql`:
+  `alter table papers add column venue text;` — additive, nullable, safe; existing rows
+  stay `NULL`.
+
+### UI: venue badge on the card
+- `components/PaperCard.tsx`: when `paper.venue` is set, render a small badge chip in
+  the top meta row (the line with category · date · signal), styled to read as an
+  acceptance tag (distinct from the accent category text — e.g. a faint bordered/tinted
+  chip). Absent `venue` → no chip, layout unchanged.
+- Conference papers also surface in **Famous** (ordered by `citations`) and **Latest**
+  (ordered by `published_at`) with no feed changes — they flow through the existing
+  ranking. No new tab or filter (explicitly out of scope; the badge is the surface).
+
+### Testing
+- `fetchConferences` / `parseS2`: a recorded S2 fixture → papers parse with
+  `venue: "NeurIPS 2024"`-style labels, arXiv IDs, citations.
+- `dedupe`: an arXiv-only paper merged with a conference paper of the same arXiv ID
+  yields one row carrying the conference `venue`.
+- `toPaperRow`: maps `venue` (including `null`).
+- `PaperCard`: renders the badge when `venue` is set; renders nothing extra when it is
+  `null`.
+
+### Operational note
+Reader HTML is cached in `paper_content` with no invalidation, but this change does not
+touch sanitize/fetch, so no cache bust is required. The new `venue` column is read
+straight from `papers`, which the cron refresh upserts.
+
+---
+
+## Out of scope
+- A dedicated "Conferences" feed/tab or venue filter (badge only this round).
+- Enabling Google Scholar / SerpAPI.
+- Backfilling `venue` for historical rows — they fill in as the cron re-ingests.
+- PDF reader behavior (the reversible-rail change is HTML-reader only, as in the
+  original read-rail spec).
+- Linking the Latest/Famous hints to their sources (only the upvotes hint was requested).

--- a/lib/corpus/dedupe.ts
+++ b/lib/corpus/dedupe.ts
@@ -35,6 +35,7 @@ export function dedupe(papers: NormalizedPaper[]): NormalizedPaper[] {
       pdfUrl: cur.pdfUrl ?? p.pdfUrl,
       sourceUrl: cur.sourceUrl ?? p.sourceUrl,
       publishedAt: cur.publishedAt ?? p.publishedAt,
+      venue: cur.venue ?? p.venue,
       categories: Array.from(new Set([...cur.categories, ...p.categories])),
       signals: {
         hfUpvotes: maxSignal(cur.signals.hfUpvotes, p.signals.hfUpvotes),

--- a/lib/corpus/upsert.ts
+++ b/lib/corpus/upsert.ts
@@ -15,6 +15,7 @@ export function toPaperRow(p: NormalizedPaper) {
     pdf_url: p.pdfUrl,
     source_url: p.sourceUrl,
     published_at: p.publishedAt,
+    venue: p.venue ?? null,
     hf_upvotes: p.signals.hfUpvotes ?? 0,
     pwc_stars: p.signals.pwcStars ?? 0,
     citations: p.signals.citations ?? 0,

--- a/lib/db/progressRow.ts
+++ b/lib/db/progressRow.ts
@@ -11,9 +11,11 @@ export interface ProgressUpdate {
 
 /**
  * Build the `reading_progress` upsert payload from a partial update. Only the
- * fields present in `update` are written so that, on conflict, every unspecified
- * column keeps its existing value — including `status`, so a debounced scroll
- * save never downgrades a finished ('done') paper back to 'reading'.
+ * fields present in `update` are written, so on conflict every unspecified
+ * column keeps its existing value — a save that omits `status` never changes it.
+ * The HTML reader, by contrast, sends `status` on every save (derived from the
+ * current read depth), so a reversible scroll-up can move a paper from 'done'
+ * back to 'reading'.
  */
 export function buildProgressRow(
   userId: string,

--- a/lib/reader/readDepth.ts
+++ b/lib/reader/readDepth.ts
@@ -1,9 +1,9 @@
 /**
  * Read-depth math, independent of the DOM so it can be unit tested.
  *
- * Read depth is the deepest point that has reached the BOTTOM of the viewport,
- * as a fraction (0–1) of the document height. The reader tracks the running max
- * of this value — it only ever increases — to drive the left-margin "read" rail.
+ * Read depth is the current viewport BOTTOM as a fraction (0–1) of the document
+ * height. The reader tracks this live value (it rises and falls with scrolling)
+ * to drive the left-margin "read" rail, so scrolling back up lowers the rail.
  */
 
 /** At/above this fraction the paper counts as finished (status -> done). */

--- a/lib/sources/conferences.ts
+++ b/lib/sources/conferences.ts
@@ -1,0 +1,57 @@
+import { env } from "@/lib/env";
+import type { NormalizedPaper } from "@/lib/types";
+import { parseS2 } from "./semanticscholar";
+
+interface ConferenceVenue {
+  /** Short badge label. */
+  label: string;
+  /** Semantic Scholar canonical venue name used for the `venue` filter. */
+  s2Venue: string;
+}
+
+const VENUES: ConferenceVenue[] = [
+  { label: "NeurIPS", s2Venue: "Neural Information Processing Systems" },
+  { label: "ICML", s2Venue: "International Conference on Machine Learning" },
+  { label: "ICLR", s2Venue: "International Conference on Learning Representations" },
+];
+
+const FIELDS = "title,abstract,year,citationCount,authors,externalIds,openAccessPdf";
+
+/** Stamp a short venue label ("NeurIPS 2024") onto parsed papers. Pure + testable. */
+export function labelConference(papers: NormalizedPaper[], label: string): NormalizedPaper[] {
+  return papers.map((p) => {
+    const year = p.publishedAt ? p.publishedAt.slice(0, 4) : null;
+    return { ...p, venue: year ? `${label} ${year}` : label };
+  });
+}
+
+/** The last two calendar years, e.g. "2025-2026" — bounds conference volume. */
+function recentYears(now: Date = new Date()): string {
+  const y = now.getUTCFullYear();
+  return `${y - 1}-${y}`;
+}
+
+/**
+ * Pull recent papers from top ML conferences (NeurIPS / ICML / ICLR) via Semantic
+ * Scholar's venue filter. No API key required (rate-limited; a 429 skips that venue).
+ * Each paper is stamped with a short venue badge label.
+ */
+export async function fetchConferences(years: string = recentYears()): Promise<NormalizedPaper[]> {
+  const key = env().SEMANTIC_SCHOLAR_API_KEY;
+  const headers: Record<string, string> = { "User-Agent": "PaperDeck/1.0 (research reader)" };
+  if (key) headers["x-api-key"] = key;
+
+  const all: NormalizedPaper[] = [];
+  for (const v of VENUES) {
+    const url =
+      `https://api.semanticscholar.org/graph/v1/paper/search?query=${encodeURIComponent(v.label)}` +
+      `&venue=${encodeURIComponent(v.s2Venue)}&year=${years}&limit=50&fields=${FIELDS}`;
+    const res = await fetch(url, { headers });
+    if (!res.ok) {
+      if (res.status === 429) continue; // expected without a key — skip this venue
+      throw new Error(`conferences ${res.status}`);
+    }
+    all.push(...labelConference(parseS2(await res.json()), v.label));
+  }
+  return all;
+}

--- a/lib/sources/conferences.ts
+++ b/lib/sources/conferences.ts
@@ -16,7 +16,7 @@ const VENUES: ConferenceVenue[] = [
 ];
 
 const FIELDS = "title,abstract,year,citationCount,authors,externalIds,openAccessPdf";
-const MAX_PER_VENUE = 50;
+const MAX_PER_VENUE = 100;
 
 /** Stamp a short venue label ("NeurIPS 2024") onto parsed papers. Pure + testable. */
 export function labelConference(papers: NormalizedPaper[], label: string): NormalizedPaper[] {
@@ -26,16 +26,25 @@ export function labelConference(papers: NormalizedPaper[], label: string): Norma
   });
 }
 
-/** The last two calendar years, e.g. "2025-2026" — bounds conference volume. */
+/**
+ * A three-year window ending at the current year, e.g. "2024-2026". Wide enough
+ * to tolerate indexing lag (the current year's proceedings are often still sparse
+ * or unindexed), narrow enough to keep the pull bounded and recent.
+ */
 function recentYears(now: Date = new Date()): string {
   const y = now.getUTCFullYear();
-  return `${y - 1}-${y}`;
+  return `${y - 2}-${y}`;
 }
 
 /**
- * Pull recent papers from top ML conferences (NeurIPS / ICML / ICLR) via Semantic
- * Scholar's venue filter. No API key required (rate-limited; a 429 skips that venue).
- * Each paper is stamped with a short venue badge label.
+ * Pull the most-cited recent papers from top ML conferences (NeurIPS / ICML /
+ * ICLR) via Semantic Scholar's *bulk* search, filtered by venue + year and sorted
+ * by citations. The relevance `/paper/search` endpoint needs a text `query` that
+ * biases results toward papers merely mentioning the venue; bulk filters purely on
+ * venue, returning the whole (sorted) proceedings — we keep the top MAX_PER_VENUE.
+ * No API key required (rate-limited; a 429 skips that venue). Each paper is stamped
+ * with a short venue badge label. Most also exist as arXiv preprints, so dedup
+ * merges the badge onto rows already in the corpus.
  */
 export async function fetchConferences(years: string = recentYears()): Promise<NormalizedPaper[]> {
   const key = env().SEMANTIC_SCHOLAR_API_KEY;
@@ -45,14 +54,16 @@ export async function fetchConferences(years: string = recentYears()): Promise<N
   const all: NormalizedPaper[] = [];
   for (const v of VENUES) {
     const url =
-      `https://api.semanticscholar.org/graph/v1/paper/search?query=${encodeURIComponent(v.label)}` +
-      `&venue=${encodeURIComponent(v.s2Venue)}&year=${years}&limit=${MAX_PER_VENUE}&fields=${FIELDS}`;
+      `https://api.semanticscholar.org/graph/v1/paper/search/bulk?venue=${encodeURIComponent(v.s2Venue)}` +
+      `&year=${years}&sort=${encodeURIComponent("citationCount:desc")}&fields=${FIELDS}`;
     const res = await fetch(url, { headers });
     if (!res.ok) {
       if (res.status === 429) continue; // expected without a key — skip this venue
       throw new Error(`conferences ${res.status}`);
     }
-    all.push(...labelConference(parseS2(await res.json()), v.label));
+    // Bulk returns the full venue sorted by citations; keep the most-cited slice.
+    const top = parseS2(await res.json()).slice(0, MAX_PER_VENUE);
+    all.push(...labelConference(top, v.label));
   }
   return all;
 }

--- a/lib/sources/conferences.ts
+++ b/lib/sources/conferences.ts
@@ -16,6 +16,7 @@ const VENUES: ConferenceVenue[] = [
 ];
 
 const FIELDS = "title,abstract,year,citationCount,authors,externalIds,openAccessPdf";
+const MAX_PER_VENUE = 50;
 
 /** Stamp a short venue label ("NeurIPS 2024") onto parsed papers. Pure + testable. */
 export function labelConference(papers: NormalizedPaper[], label: string): NormalizedPaper[] {
@@ -45,7 +46,7 @@ export async function fetchConferences(years: string = recentYears()): Promise<N
   for (const v of VENUES) {
     const url =
       `https://api.semanticscholar.org/graph/v1/paper/search?query=${encodeURIComponent(v.label)}` +
-      `&venue=${encodeURIComponent(v.s2Venue)}&year=${years}&limit=50&fields=${FIELDS}`;
+      `&venue=${encodeURIComponent(v.s2Venue)}&year=${years}&limit=${MAX_PER_VENUE}&fields=${FIELDS}`;
     const res = await fetch(url, { headers });
     if (!res.ok) {
       if (res.status === 429) continue; // expected without a key — skip this venue

--- a/lib/sources/index.ts
+++ b/lib/sources/index.ts
@@ -4,6 +4,7 @@ import { fetchArxivLatest } from "./arxiv";
 import { fetchHfDaily } from "./huggingface";
 import { fetchPwcTrending } from "./paperswithcode";
 import { fetchS2Famous } from "./semanticscholar";
+import { fetchConferences } from "./conferences";
 import { fetchScholar } from "./googlescholar";
 
 export interface Source {
@@ -29,6 +30,7 @@ export function sources(): Source[] {
     { id: "huggingface", enabled: true, run: () => fetchHfDaily() },
     { id: "paperswithcode", enabled: false, run: () => fetchPwcTrending() },
     { id: "semanticscholar", enabled: true, run: () => fetchS2Famous() },
+    { id: "conferences", enabled: true, run: () => fetchConferences() },
     { id: "googlescholar", enabled: Boolean(e.SERPAPI_KEY), run: () => fetchScholar() },
   ];
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -3,7 +3,8 @@ export type SourceId =
   | "huggingface"
   | "paperswithcode"
   | "semanticscholar"
-  | "googlescholar";
+  | "googlescholar"
+  | "conferences";
 
 /** The common shape every source adapter normalizes its results into. */
 export interface NormalizedPaper {
@@ -18,6 +19,8 @@ export interface NormalizedPaper {
   sourceUrl: string | null;
   /** ISO 8601 string. */
   publishedAt: string | null;
+  /** Short conference label, e.g. "NeurIPS 2024". Set only by the conferences source. */
+  venue?: string | null;
   signals: PaperSignals;
 }
 
@@ -40,6 +43,7 @@ export interface PaperRow {
   pdf_url: string | null;
   source_url: string | null;
   published_at: string | null;
+  venue?: string | null;
   hf_upvotes: number;
   pwc_stars: number;
   citations: number;

--- a/supabase/migrations/0005_papers_venue.sql
+++ b/supabase/migrations/0005_papers_venue.sql
@@ -1,0 +1,4 @@
+-- Add a conference venue label (e.g. "NeurIPS 2024") to the shared corpus.
+-- Nullable and additive: populated by the conferences source and merged onto
+-- matching arXiv rows; existing rows stay NULL and backfill as the cron re-ingests.
+alter table papers add column if not exists venue text;

--- a/tests/components/FeedTabs.test.tsx
+++ b/tests/components/FeedTabs.test.tsx
@@ -14,4 +14,8 @@ test("non-trending hints are plain text, not links", () => {
   render(<FeedTabs active="latest" />);
   const hint = screen.getByText("freshest arXiv submissions");
   expect(hint.closest("a")).toBeNull();
+
+  render(<FeedTabs active="famous" />);
+  const famousHint = screen.getByText("ranked by citations");
+  expect(famousHint.closest("a")).toBeNull();
 });

--- a/tests/components/FeedTabs.test.tsx
+++ b/tests/components/FeedTabs.test.tsx
@@ -1,0 +1,17 @@
+import { test, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { FeedTabs } from "@/components/FeedTabs";
+
+test("the Trending hint links to the Hugging Face papers page", () => {
+  render(<FeedTabs active="trending" />);
+  const link = screen.getByRole("link", { name: /ranked by community upvotes/i });
+  expect(link).toHaveAttribute("href", "https://huggingface.co/papers");
+  expect(link).toHaveAttribute("target", "_blank");
+  expect(link).toHaveAttribute("rel", "noreferrer");
+});
+
+test("non-trending hints are plain text, not links", () => {
+  render(<FeedTabs active="latest" />);
+  const hint = screen.getByText("freshest arXiv submissions");
+  expect(hint.closest("a")).toBeNull();
+});

--- a/tests/components/HtmlReader.test.tsx
+++ b/tests/components/HtmlReader.test.tsx
@@ -1,5 +1,5 @@
 import { test, expect, vi, beforeEach } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 
 // Mock the server action chain (next/headers) so the client component mounts in jsdom.
 const { saveProgress } = vi.hoisted(() => ({
@@ -20,6 +20,15 @@ beforeEach(() => {
 
 function renderReader(progress: ProgressRow | null) {
   return render(<HtmlReader paperId="p1" html={HTML} initialProgress={progress} />);
+}
+
+function setGeometry(scrollY: number, innerHeight: number, scrollHeight: number) {
+  Object.defineProperty(window, "scrollY", { value: scrollY, configurable: true });
+  Object.defineProperty(window, "innerHeight", { value: innerHeight, configurable: true });
+  Object.defineProperty(document.documentElement, "scrollHeight", {
+    value: scrollHeight,
+    configurable: true,
+  });
 }
 
 test("renders the paper HTML content", () => {
@@ -53,4 +62,20 @@ test("an unread paper shows an empty rail", () => {
   const rail = container.querySelector<HTMLElement>('[data-testid="read-rail"]');
   expect(rail).not.toBeNull();
   expect(rail!.style.height).toBe("0%");
+});
+
+test("the read rail follows current scroll depth and shrinks on scroll up", () => {
+  const { container } = renderReader(null);
+  const rail = () => container.querySelector<HTMLElement>('[data-testid="read-rail"]')!;
+
+  // Doc 1000px, viewport 200px. scrollY=300 => (300+200)/1000 = 0.5.
+  setGeometry(300, 200, 1000);
+  fireEvent.scroll(window);
+  expect(rail().style.height).toBe("50%");
+
+  // Scroll back up: scrollY=50 => (50+200)/1000 = 0.25. A monotonic rail would
+  // stay at 50%; the reversible rail drops to 25%.
+  setGeometry(50, 200, 1000);
+  fireEvent.scroll(window);
+  expect(rail().style.height).toBe("25%");
 });

--- a/tests/components/HtmlReader.test.tsx
+++ b/tests/components/HtmlReader.test.tsx
@@ -1,5 +1,5 @@
 import { test, expect, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, act } from "@testing-library/react";
 
 // Mock the server action chain (next/headers) so the client component mounts in jsdom.
 const { saveProgress } = vi.hoisted(() => ({
@@ -78,4 +78,25 @@ test("the read rail follows current scroll depth and shrinks on scroll up", () =
   setGeometry(50, 200, 1000);
   fireEvent.scroll(window);
   expect(rail().style.height).toBe("25%");
+});
+
+test("scrolling past the end then back up persists status done, then reading", () => {
+  vi.useFakeTimers();
+  try {
+    renderReader(null);
+
+    // Scroll to the bottom (>= 0.98): (790 + 200) / 1000 = 0.99 -> done
+    setGeometry(790, 200, 1000);
+    fireEvent.scroll(window);
+    act(() => vi.advanceTimersByTime(600)); // flush the 600ms debounced persist
+    expect(saveProgress.mock.calls.at(-1)?.[1]).toMatchObject({ status: "done" });
+
+    // Scroll back up (0.5): (300 + 200) / 1000 = 0.5 -> reading (done un-marks)
+    setGeometry(300, 200, 1000);
+    fireEvent.scroll(window);
+    act(() => vi.advanceTimersByTime(600));
+    expect(saveProgress.mock.calls.at(-1)?.[1]).toMatchObject({ status: "reading" });
+  } finally {
+    vi.useRealTimers();
+  }
 });

--- a/tests/components/PaperCard.test.tsx
+++ b/tests/components/PaperCard.test.tsx
@@ -70,3 +70,13 @@ test("shows reading progress when started", () => {
   render(<PaperCard paper={paper} starred={false} progressPct={0.34} />);
   expect(screen.getByText("34%")).toBeInTheDocument();
 });
+
+test("renders a venue badge when the paper has a venue", () => {
+  render(<PaperCard paper={{ ...paper, venue: "NeurIPS 2024" }} starred={false} />);
+  expect(screen.getByText("NeurIPS 2024")).toBeInTheDocument();
+});
+
+test("omits the venue badge when there is no venue", () => {
+  render(<PaperCard paper={paper} starred={false} />);
+  expect(screen.queryByText(/NeurIPS|ICML|ICLR/)).toBeNull();
+});

--- a/tests/corpus/dedupe.test.ts
+++ b/tests/corpus/dedupe.test.ts
@@ -55,3 +55,20 @@ test("dedupeKey falls back arxiv -> doi -> normalized title", () => {
 test("distinct papers are preserved", () => {
   expect(dedupe([base({ arxivId: "a" }), base({ arxivId: "b" })])).toHaveLength(2);
 });
+
+test("an arxiv row inherits a conference venue when merged", () => {
+  const merged = dedupe([
+    base({ arxivId: "2401.9" }),
+    base({ arxivId: "2401.9", venue: "NeurIPS 2024" }),
+  ]);
+  expect(merged).toHaveLength(1);
+  expect(merged[0].venue).toBe("NeurIPS 2024");
+});
+
+test("venue survives regardless of merge order", () => {
+  const merged = dedupe([
+    base({ arxivId: "2401.10", venue: "ICML 2025" }),
+    base({ arxivId: "2401.10" }),
+  ]);
+  expect(merged[0].venue).toBe("ICML 2025");
+});

--- a/tests/corpus/dedupe.test.ts
+++ b/tests/corpus/dedupe.test.ts
@@ -70,5 +70,6 @@ test("venue survives regardless of merge order", () => {
     base({ arxivId: "2401.10", venue: "ICML 2025" }),
     base({ arxivId: "2401.10" }),
   ]);
+  expect(merged).toHaveLength(1);
   expect(merged[0].venue).toBe("ICML 2025");
 });

--- a/tests/corpus/upsert.test.ts
+++ b/tests/corpus/upsert.test.ts
@@ -1,0 +1,26 @@
+import { test, expect } from "vitest";
+import { toPaperRow } from "@/lib/corpus/upsert";
+import type { NormalizedPaper } from "@/lib/types";
+
+const base = (o: Partial<NormalizedPaper>): NormalizedPaper => ({
+  arxivId: "2401.1",
+  doi: null,
+  title: "T",
+  authors: [],
+  abstract: null,
+  categories: [],
+  htmlUrl: null,
+  pdfUrl: null,
+  sourceUrl: null,
+  publishedAt: null,
+  signals: {},
+  ...o,
+});
+
+test("maps a venue when present", () => {
+  expect(toPaperRow(base({ venue: "NeurIPS 2024" })).venue).toBe("NeurIPS 2024");
+});
+
+test("maps a missing venue to null", () => {
+  expect(toPaperRow(base({})).venue).toBeNull();
+});

--- a/tests/sources/conferences.test.ts
+++ b/tests/sources/conferences.test.ts
@@ -1,0 +1,33 @@
+import { test, expect } from "vitest";
+import { labelConference } from "@/lib/sources/conferences";
+import type { NormalizedPaper } from "@/lib/types";
+
+const paper = (publishedAt: string | null): NormalizedPaper => ({
+  arxivId: "2401.1",
+  doi: null,
+  title: "T",
+  authors: [],
+  abstract: null,
+  categories: [],
+  htmlUrl: null,
+  pdfUrl: null,
+  sourceUrl: null,
+  publishedAt,
+  signals: { citations: 5 },
+});
+
+test("stamps a short venue label with the publication year", () => {
+  const [p] = labelConference([paper("2024-01-01T00:00:00Z")], "NeurIPS");
+  expect(p.venue).toBe("NeurIPS 2024");
+});
+
+test("falls back to the bare label when the year is unknown", () => {
+  const [p] = labelConference([paper(null)], "ICLR");
+  expect(p.venue).toBe("ICLR");
+});
+
+test("leaves the other fields intact", () => {
+  const [p] = labelConference([paper("2025-01-01T00:00:00Z")], "ICML");
+  expect(p.arxivId).toBe("2401.1");
+  expect(p.signals.citations).toBe(5);
+});


### PR DESCRIPTION
Three independent improvements, requested together. Spec: `docs/superpowers/specs/2026-06-14-reader-and-sources-improvements-design.md` · Plan: `docs/superpowers/plans/2026-06-14-reader-and-sources-improvements.md`.

## 1. Link the Trending hint to its source
The "ranked by community upvotes" hint on the Trending tab now links to https://huggingface.co/papers (where the upvotes come from). Latest/Famous hints stay plain text. (`components/FeedTabs.tsx`)

## 2. Fully reversible read rail
The HTML reader's read rail now tracks the **current** scroll depth instead of a session maximum. Scrolling up lowers the rail, and scrolling back above the 0.98 done-threshold returns a paper from `done` to `reading` — so an accidental fling to the bottom is fully recoverable. No schema change (`read_pct` already existed); the whole behavior change is dropping the monotonic max-guard. (`components/HtmlReader.tsx`, `lib/reader/readDepth.ts`)

- PDF reader is unaffected (it never writes `read_pct`; the shelf's `max(read_pct, scroll_pct)` still falls back to `scroll_pct`).

## 3. Conference papers (NeurIPS / ICLR / ICML) + venue badge
New `conferences` source pulls accepted papers from those three venues via Semantic Scholar's venue filter (free, no API key; 429-tolerant). A new optional `venue` field flows source → dedup → upsert → a `venue` DB column → a badge on the paper card. Because most conference papers also have an arXiv preprint, dedup **merges the venue onto existing arXiv rows** — so papers already in the corpus light up with a "NeurIPS 2024"-style acceptance badge. (`lib/sources/conferences.ts`, `lib/types.ts`, `lib/corpus/dedupe.ts`, `lib/corpus/upsert.ts`, `lib/sources/index.ts`, `supabase/migrations/0005_papers_venue.sql`, `components/PaperCard.tsx`)

## Testing
- `pnpm test` → 110 passed / 27 files; `pnpm typecheck` clean; `pnpm lint` 0 errors (4 pre-existing warnings).
- TDD throughout. Notable coverage: rail reversibility (shrinks on scroll-up) and the `done → reading` un-mark at the persistence layer; dedup carries `venue` regardless of merge order; `toPaperRow` maps `venue`; card renders/omits the badge.

## Deploy notes
- **Migration `0005_papers_venue.sql` already applied** to the live `paper-deck` Supabase project (additive, nullable column) — done before this push so the cron upsert can't hit an unknown column.
- No new env vars or dependencies required.
- After the next cron refresh, confirm conference badges appear; the exact Semantic Scholar `venue`/`year` params in `lib/sources/conferences.ts` may need light tuning (a venue returning nothing is non-fatal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)