### PR TITLE
feat(reader): text highlights + notes (v1)

### DIFF
--- a/app/actions/highlights.ts
+++ b/app/actions/highlights.ts
@@ -1,0 +1,66 @@
+"use server";
+
+import { serverClient } from "@/lib/db/server";
+import { currentUser } from "@/lib/auth";
+import type { Highlight } from "@/lib/types";
+import {
+  highlightInputSchema,
+  highlightInsert,
+  rowToHighlight,
+  NOTE_MAX,
+  type HighlightInput,
+  type HighlightRow,
+} from "@/lib/db/highlightRow";
+
+const HL_COLS = "id, paper_id, block_anchor, start_offset, end_offset, quote, note";
+
+/** All of the current user's highlights for a paper (oldest first). Empty when signed out. */
+export async function loadHighlights(paperId: string): Promise<Highlight[]> {
+  const user = await currentUser();
+  if (!user) return [];
+  const db = await serverClient();
+  const { data } = await db
+    .from("highlights")
+    .select(HL_COLS)
+    .eq("user_id", user.id)
+    .eq("paper_id", paperId)
+    .order("created_at", { ascending: true });
+  return ((data as HighlightRow[] | null) ?? []).map(rowToHighlight);
+}
+
+/** Create a highlight; returns the saved row (with id) for optimistic painting, or null. */
+export async function createHighlight(input: HighlightInput): Promise<Highlight | null> {
+  const user = await currentUser();
+  if (!user) return null;
+  const parsed = highlightInputSchema.safeParse(input);
+  if (!parsed.success) return null;
+  const db = await serverClient();
+  const { data, error } = await db
+    .from("highlights")
+    .insert(highlightInsert(user.id, parsed.data))
+    .select(HL_COLS)
+    .single();
+  if (error || !data) return null;
+  return rowToHighlight(data as HighlightRow);
+}
+
+/** Set (or clear) the note on a highlight the user owns. */
+export async function updateHighlightNote(id: string, note: string | null): Promise<void> {
+  const user = await currentUser();
+  if (!user) return;
+  const capped = note && note.length > NOTE_MAX ? note.slice(0, NOTE_MAX) : note;
+  const db = await serverClient();
+  await db
+    .from("highlights")
+    .update({ note: capped ?? null, updated_at: new Date().toISOString() })
+    .eq("id", id)
+    .eq("user_id", user.id);
+}
+
+/** Delete a highlight the user owns. */
+export async function deleteHighlight(id: string): Promise<void> {
+  const user = await currentUser();
+  if (!user) return;
+  const db = await serverClient();
+  await db.from("highlights").delete().eq("id", id).eq("user_id", user.id);
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -20,6 +20,8 @@
   --tint: #f1ebdf;
   --read-tint: #f8f0dc;
   --read-accent: #d9a441;
+  --highlight-bg: rgba(217, 164, 65, 0.34); /* translucent amber */
+  --highlight-line: rgba(217, 164, 65, 0.9);
   --shadow: rgba(46, 32, 18, 0.1);
   --danger: #b3261e;
   color-scheme: light;
@@ -39,6 +41,8 @@
   --tint: #252018;
   --read-tint: #2b2414;
   --read-accent: #b98a3a;
+  --highlight-bg: rgba(185, 138, 58, 0.4);
+  --highlight-line: rgba(185, 138, 58, 0.95);
   --shadow: rgba(0, 0, 0, 0.45);
   --danger: #e2685c;
   color-scheme: dark;
@@ -114,6 +118,23 @@ html .paper-html {
 
 [data-theme="dark"] .paper-html img {
   filter: brightness(0.85) contrast(1.1);
+}
+
+/* ---- Reader: user highlights ---- */
+mark.pd-highlight {
+  background: var(--highlight-bg);
+  color: inherit;
+  border-radius: 2px;
+  padding: 0 0.5px;
+  cursor: pointer;
+  -webkit-box-decoration-break: clone;
+  box-decoration-break: clone;
+}
+/* highlights that carry a note get a subtle underline cue */
+mark.pd-highlight[data-hl-note="1"] {
+  text-decoration: underline;
+  text-decoration-color: var(--highlight-line);
+  text-underline-offset: 3px;
 }
 
 /* thin scrollbars on horizontal shelves */

--- a/app/reader/[id]/page.tsx
+++ b/app/reader/[id]/page.tsx
@@ -3,6 +3,7 @@ import { notFound, redirect } from "next/navigation";
 import { ReaderView } from "@/components/ReaderView";
 import { getPaper } from "@/lib/corpus/query";
 import { loadProgress } from "@/app/actions/progress";
+import { loadHighlights } from "@/app/actions/highlights";
 import { currentUser } from "@/lib/auth";
 
 export const dynamic = "force-dynamic";
@@ -22,6 +23,7 @@ export default async function ReaderPage({ params }: { params: Promise<{ id: str
   if (!paper) notFound();
 
   const progress = await loadProgress(id);
+  const highlights = await loadHighlights(id);
 
   return (
     <div>
@@ -39,7 +41,7 @@ export default async function ReaderPage({ params }: { params: Promise<{ id: str
           </h1>
         </div>
       </div>
-      <ReaderView paperId={id} initialProgress={progress} />
+      <ReaderView paperId={id} initialProgress={progress} initialHighlights={highlights} />
     </div>
   );
 }

--- a/components/HighlightLayer.tsx
+++ b/components/HighlightLayer.tsx
@@ -1,0 +1,211 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { RefObject } from "react";
+import { createHighlight, deleteHighlight, updateHighlightNote } from "@/app/actions/highlights";
+import {
+  offsetsFromSelection,
+  decorateBlock,
+  clearHighlights,
+  MARK_CLASS,
+  type DecorateTarget,
+} from "@/lib/reader/highlightRange";
+import { Button } from "@/components/ui";
+import type { Highlight } from "@/lib/types";
+
+type Pending = {
+  x: number;
+  y: number;
+  blockAnchor: string;
+  start: number;
+  end: number;
+  quote: string;
+};
+type Editing = { id: string; x: number; y: number };
+
+export function HighlightLayer({
+  paperId,
+  containerRef,
+  initialHighlights,
+}: {
+  paperId: string;
+  containerRef: RefObject<HTMLDivElement | null>;
+  initialHighlights: Highlight[];
+}) {
+  const [highlights, setHighlights] = useState<Highlight[]>(initialHighlights);
+  const [pending, setPending] = useState<Pending | null>(null);
+  const [editing, setEditing] = useState<Editing | null>(null);
+  const [noteDraft, setNoteDraft] = useState("");
+
+  // Keep a ref so click handlers bound into the DOM read current highlights
+  // without changing identity (which would thrash the repaint effect).
+  const hlRef = useRef(highlights);
+  useEffect(() => {
+    hlRef.current = highlights;
+  }, [highlights]);
+
+  const openEditor = useCallback(
+    (id: string) => {
+      const root = containerRef.current;
+      const mark = root?.querySelector<HTMLElement>(`mark.${MARK_CLASS}[data-hl-id="${id}"]`);
+      const rect = mark?.getBoundingClientRect();
+      const h = hlRef.current.find((x) => x.id === id);
+      setEditing({ id, x: rect?.left ?? 0, y: rect?.bottom ?? 0 });
+      setNoteDraft(h?.note ?? "");
+    },
+    [containerRef],
+  );
+
+  // (Re)paint marks whenever the highlight set changes.
+  useEffect(() => {
+    const root = containerRef.current;
+    if (!root) return;
+    clearHighlights(root);
+    const byBlock = new Map<string, DecorateTarget[]>();
+    for (const h of highlights) {
+      const target: DecorateTarget = {
+        id: h.id,
+        startOffset: h.startOffset,
+        endOffset: h.endOffset,
+        quote: h.quote,
+        hasNote: !!h.note,
+      };
+      const arr = byBlock.get(h.blockAnchor) ?? [];
+      arr.push(target);
+      byBlock.set(h.blockAnchor, arr);
+    }
+    for (const [blk, targets] of byBlock) {
+      const block = root.querySelector(`[data-blk="${blk}"]`);
+      if (block) decorateBlock(block, targets, openEditor);
+    }
+    return () => clearHighlights(root);
+  }, [highlights, containerRef, openEditor]);
+
+  // Show the "Highlight" button when a fresh selection sits inside one block.
+  useEffect(() => {
+    function onMouseUp() {
+      const root = containerRef.current;
+      const sel = window.getSelection();
+      if (!root || !sel || sel.isCollapsed || sel.rangeCount === 0) {
+        setPending(null);
+        return;
+      }
+      const range = sel.getRangeAt(0);
+      const block = (range.startContainer.parentElement ?? null)?.closest("[data-blk]");
+      if (!block || !root.contains(block)) {
+        setPending(null);
+        return;
+      }
+      // No overlaps in v1: ignore selections that touch an existing mark.
+      if (range.cloneContents().querySelector(`mark.${MARK_CLASS}`)) {
+        setPending(null);
+        return;
+      }
+      const offsets = offsetsFromSelection(block, range);
+      if (!offsets) {
+        setPending(null);
+        return;
+      }
+      // Range.getBoundingClientRect exists in browsers but not jsdom; fall back to 0s.
+      const rect =
+        typeof range.getBoundingClientRect === "function"
+          ? range.getBoundingClientRect()
+          : { left: 0, top: 0, width: 0 };
+      setPending({
+        x: rect.left + rect.width / 2,
+        y: rect.top,
+        blockAnchor: block.getAttribute("data-blk") ?? "",
+        start: offsets.start,
+        end: offsets.end,
+        quote: offsets.quote,
+      });
+    }
+    document.addEventListener("mouseup", onMouseUp);
+    return () => document.removeEventListener("mouseup", onMouseUp);
+  }, [containerRef]);
+
+  async function confirmHighlight() {
+    if (!pending) return;
+    const created = await createHighlight({
+      paperId,
+      blockAnchor: pending.blockAnchor,
+      startOffset: pending.start,
+      endOffset: pending.end,
+      quote: pending.quote,
+      note: null,
+    });
+    setPending(null);
+    window.getSelection()?.removeAllRanges();
+    if (created) setHighlights((hs) => [...hs, created]);
+  }
+
+  async function saveNote() {
+    if (!editing) return;
+    const note = noteDraft.trim() || null;
+    await updateHighlightNote(editing.id, note);
+    setHighlights((hs) => hs.map((h) => (h.id === editing.id ? { ...h, note } : h)));
+    setEditing(null);
+  }
+
+  async function removeHighlight() {
+    if (!editing) return;
+    await deleteHighlight(editing.id);
+    setHighlights((hs) => hs.filter((h) => h.id !== editing.id));
+    setEditing(null);
+  }
+
+  return (
+    <>
+      {pending && (
+        <div
+          className="pd-enter fixed z-30 -translate-x-1/2 -translate-y-full pb-2"
+          style={{ left: pending.x, top: pending.y }}
+        >
+          <Button
+            variant="primary"
+            className="h-8 px-3 text-xs shadow-md"
+            onClick={confirmHighlight}
+          >
+            Highlight
+          </Button>
+        </div>
+      )}
+
+      {editing && (
+        <div
+          className="pd-enter fixed z-30 w-72 rounded-xl border border-line bg-card p-3 shadow-lg"
+          style={{ left: editing.x, top: editing.y + 6 }}
+        >
+          <textarea
+            aria-label="Note"
+            className="h-24 w-full resize-none rounded-md border border-line bg-background p-2 text-sm text-ink focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/50"
+            placeholder="Add a note…"
+            value={noteDraft}
+            onChange={(e) => setNoteDraft(e.target.value)}
+          />
+          <div className="mt-2 flex items-center justify-between">
+            <button
+              type="button"
+              onClick={removeHighlight}
+              className="text-xs font-medium text-danger hover:underline"
+            >
+              Delete
+            </button>
+            <div className="flex gap-2">
+              <Button
+                variant="ghost"
+                className="h-8 px-3 text-xs"
+                onClick={() => setEditing(null)}
+              >
+                Cancel
+              </Button>
+              <Button variant="primary" className="h-8 px-3 text-xs" onClick={saveNote}>
+                Save
+              </Button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/components/HtmlReader.tsx
+++ b/components/HtmlReader.tsx
@@ -5,7 +5,8 @@ import { saveProgress } from "@/app/actions/progress";
 import { resolveResumeTarget } from "@/lib/reader/anchor";
 import { readDepthFraction, isComplete } from "@/lib/reader/readDepth";
 import { ReaderProgressBar } from "@/components/ReaderProgressBar";
-import type { ProgressRow } from "@/lib/types";
+import { HighlightLayer } from "@/components/HighlightLayer";
+import type { ProgressRow, Highlight } from "@/lib/types";
 
 const HEADER_OFFSET = 72; // sticky header height-ish
 
@@ -15,10 +16,12 @@ export function HtmlReader({
   paperId,
   html,
   initialProgress,
+  initialHighlights = [],
 }: {
   paperId: string;
   html: string;
   initialProgress: ProgressRow | null;
+  initialHighlights?: Highlight[];
 }) {
   const containerRef = useRef<HTMLDivElement>(null);
   // Read depth = current scroll fraction (viewport bottom). Reversible: scrolling up lowers it.
@@ -123,6 +126,11 @@ export function HtmlReader({
           ref={containerRef}
           className="paper-html px-4 pb-28 pt-6"
           dangerouslySetInnerHTML={content}
+        />
+        <HighlightLayer
+          paperId={paperId}
+          containerRef={containerRef}
+          initialHighlights={initialHighlights}
         />
       </div>
       <ReaderProgressBar pct={readPct} />

--- a/components/ReaderView.tsx
+++ b/components/ReaderView.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from "react";
 import dynamic from "next/dynamic";
 import { HtmlReader } from "@/components/HtmlReader";
 import { LinkButton } from "@/components/ui";
-import type { ProgressRow } from "@/lib/types";
+import type { ProgressRow, Highlight } from "@/lib/types";
 
 const PdfReader = dynamic(() => import("@/components/PdfReader").then((m) => m.PdfReader), {
   ssr: false,
@@ -33,9 +33,11 @@ function ReaderSkeleton() {
 export function ReaderView({
   paperId,
   initialProgress,
+  initialHighlights,
 }: {
   paperId: string;
   initialProgress: ProgressRow | null;
+  initialHighlights: Highlight[];
 }) {
   const [payload, setPayload] = useState<Payload | null>(null);
 
@@ -61,7 +63,14 @@ export function ReaderView({
   }
 
   if (payload.kind === "html") {
-    return <HtmlReader paperId={paperId} html={payload.html} initialProgress={initialProgress} />;
+    return (
+      <HtmlReader
+        paperId={paperId}
+        html={payload.html}
+        initialProgress={initialProgress}
+        initialHighlights={initialHighlights}
+      />
+    );
   }
 
   if (payload.kind === "pdf") {

--- a/docs/superpowers/plans/2026-06-23-highlights-notes.md
+++ b/docs/superpowers/plans/2026-06-23-highlights-notes.md
@@ -1,0 +1,1444 @@
+# Highlights & Notes Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let signed-in users select text in the HTML reader, highlight it, and attach an optional note — rendered inline on re-open and editable by clicking the highlight.
+
+**Architecture:** Highlights anchor to the reader's existing `data-blk` block indices plus character offsets into that block's normalized `textContent`. They are stored per-user (RLS) and painted client-side as `<mark>` elements after the cached HTML mounts, so per-user data never enters the shared `paper_content` cache. Pure offset math is isolated for unit testing; a `HighlightLayer` component owns the selection toolbar, decoration, and note popover.
+
+**Tech Stack:** Next 16 (App Router, Server Actions), React 19, Supabase (Postgres + RLS), Zod 4, Vitest + jsdom + @testing-library/react, Tailwind v4.
+
+## Global Constraints
+
+- **Spec:** `docs/superpowers/specs/2026-06-23-highlights-notes-design.md` (authoritative).
+- **Scope:** HTML reader only; text-selection granularity; single-block (clamp); optional note per highlight; in-reader surfacing only; single highlight color; overlaps disallowed at creation.
+- **Tests live in the parallel `tests/` tree**, mirroring source paths (e.g. `lib/x.ts` → `tests/x.test.ts`). Never co-locate tests with source. Test runner: `pnpm test` (Vitest, jsdom, `@` aliased to repo root).
+- **Server actions** follow the `app/actions/progress.ts` shape: `"use server"`, `currentUser()` guard, `serverClient()`, RLS enforces ownership; defense-in-depth `.eq("user_id", user.id)` on every per-user query.
+- **Supabase project id:** `rrbmucsbqsoyspsoftvl`. Migration files are `if not exists` / `drop policy if exists` (idempotent); the repo uses `000N_` prefixes while the MCP ledger uses timestamp versions (both fine).
+- **Dev server:** `pnpm dev` runs webpack (`next dev --webpack`) — do NOT use Turbopack.
+- **Every commit message** ends with the two standard trailers (shown once here; later steps abbreviate as "(+ trailers)"):
+  ```
+  Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+  Claude-Session: https://claude.ai/code/session_01UmWCgJgpZye1LWFftWeT5G
+  ```
+- Run `pnpm typecheck` and `pnpm test` before the final commit of each task.
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `supabase/migrations/0006_highlights.sql` | `highlights` table + index + RLS (new) |
+| `lib/types.ts` | `Highlight` app type (modify: append) |
+| `lib/db/highlightRow.ts` | row⇄`Highlight` mappers, insert builder, Zod input schema, length caps (new) |
+| `lib/reader/highlightRange.ts` | pure offset math + DOM adapters (selection→offsets, decorate, clear) (new) |
+| `app/actions/highlights.ts` | `loadHighlights` / `createHighlight` / `updateHighlightNote` / `deleteHighlight` server actions (new) |
+| `components/HighlightLayer.tsx` | selection toolbar, decoration orchestration, note popover (new) |
+| `components/HtmlReader.tsx` | mount `HighlightLayer`, pass `containerRef` + `initialHighlights` (modify) |
+| `components/ReaderView.tsx` | thread `initialHighlights` to `HtmlReader` (modify) |
+| `app/reader/[id]/page.tsx` | load `initialHighlights` server-side (modify) |
+| `app/globals.css` | `.pd-highlight` styles + `--highlight-bg` token (modify) |
+| `tests/db/highlightRow.test.ts`, `tests/reader/highlightRange.test.ts`, `tests/actions/highlights.test.ts`, `tests/components/HighlightLayer.test.tsx` | tests (new) |
+| `tests/components/HtmlReader.test.tsx` | add highlights-action mock + integration assertion (modify) |
+
+---
+
+## Task 1: Database migration + `Highlight` type
+
+**Files:**
+- Create: `supabase/migrations/0006_highlights.sql`
+- Modify: `lib/types.ts` (append the `Highlight` interface)
+
+**Interfaces:**
+- Produces: SQL table `highlights(id, user_id, paper_id, block_anchor, start_offset, end_offset, quote, note, created_at, updated_at)`; TS `Highlight { id, paperId, blockAnchor, startOffset, endOffset, quote, note }`.
+
+- [ ] **Step 1: Write the migration**
+
+Create `supabase/migrations/0006_highlights.sql`:
+
+```sql
+-- Per-user text highlights + optional notes for the HTML reader.
+-- Anchored to a block's data-blk index plus char offsets into its textContent.
+create table if not exists highlights (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  paper_id uuid not null references papers(id) on delete cascade,
+  block_anchor text not null,      -- the data-blk value, e.g. "12"
+  start_offset int not null,       -- char index into the block's textContent
+  end_offset int not null,         -- exclusive
+  quote text not null,             -- selected text: drift detection + popover display
+  note text,                       -- optional comment (nullable)
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  check (start_offset >= 0 and end_offset > start_offset)
+);
+create index if not exists highlights_user_paper_idx
+  on highlights (user_id, paper_id, created_at);
+
+alter table highlights enable row level security;
+
+drop policy if exists "highlights owner" on highlights;
+create policy "highlights owner" on highlights
+  for all using (auth.uid() = user_id) with check (auth.uid() = user_id);
+```
+
+- [ ] **Step 2: Apply the migration to the Supabase project**
+
+Use the Supabase MCP `apply_migration` tool (project id `rrbmucsbqsoyspsoftvl`, name `highlights`) with the SQL body above. (Local dev picks the file up on the next `npx supabase db reset` / `start`.)
+
+- [ ] **Step 3: Verify the table exists**
+
+Use the Supabase MCP `list_tables` tool and confirm a `highlights` table with the columns above and RLS enabled.
+Expected: table present, `rls_enabled: true`, policy `highlights owner`.
+
+- [ ] **Step 4: Append the `Highlight` type**
+
+In `lib/types.ts`, after the `ProgressRow` interface, append:
+
+```ts
+/** A user's text highlight (+ optional note) within a paper's HTML reader. */
+export interface Highlight {
+  id: string;
+  paperId: string;
+  blockAnchor: string;
+  /** Char offset into the block's textContent (inclusive). */
+  startOffset: number;
+  /** Char offset into the block's textContent (exclusive). */
+  endOffset: number;
+  /** The selected text — used to display the note and to detect anchor drift. */
+  quote: string;
+  note: string | null;
+}
+```
+
+- [ ] **Step 5: Typecheck + commit**
+
+Run: `pnpm typecheck`
+Expected: no errors.
+
+```bash
+git add supabase/migrations/0006_highlights.sql lib/types.ts
+git commit -m "feat(highlights): add highlights table, RLS, and Highlight type"  # (+ trailers)
+```
+
+---
+
+## Task 2: Row mappers + Zod input schema (`lib/db/highlightRow.ts`)
+
+**Files:**
+- Create: `lib/db/highlightRow.ts`
+- Test: `tests/db/highlightRow.test.ts`
+
+**Interfaces:**
+- Consumes: `Highlight` (Task 1).
+- Produces:
+  - `interface HighlightRow { id; paper_id; block_anchor; start_offset; end_offset; quote; note }`
+  - `const NOTE_MAX = 2000`, `const QUOTE_MAX = 1000`
+  - `highlightInputSchema` (Zod) + `type HighlightInput`
+  - `rowToHighlight(row: HighlightRow): Highlight`
+  - `highlightInsert(userId: string, input: HighlightInput): { user_id; paper_id; block_anchor; start_offset; end_offset; quote; note }`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/db/highlightRow.test.ts`:
+
+```ts
+import { test, expect } from "vitest";
+import {
+  rowToHighlight,
+  highlightInsert,
+  highlightInputSchema,
+  type HighlightRow,
+} from "@/lib/db/highlightRow";
+
+const ROW: HighlightRow = {
+  id: "h1",
+  paper_id: "p1",
+  block_anchor: "12",
+  start_offset: 3,
+  end_offset: 9,
+  quote: "sample",
+  note: "a note",
+};
+
+test("rowToHighlight maps snake_case columns to the camelCase app shape", () => {
+  expect(rowToHighlight(ROW)).toEqual({
+    id: "h1",
+    paperId: "p1",
+    blockAnchor: "12",
+    startOffset: 3,
+    endOffset: 9,
+    quote: "sample",
+    note: "a note",
+  });
+});
+
+test("highlightInsert builds the row payload with the user id and null note default", () => {
+  expect(
+    highlightInsert("user-1", {
+      paperId: "p1",
+      blockAnchor: "12",
+      startOffset: 3,
+      endOffset: 9,
+      quote: "sample",
+    }),
+  ).toEqual({
+    user_id: "user-1",
+    paper_id: "p1",
+    block_anchor: "12",
+    start_offset: 3,
+    end_offset: 9,
+    quote: "sample",
+    note: null,
+  });
+});
+
+test("schema rejects an empty selection (end <= start)", () => {
+  const r = highlightInputSchema.safeParse({
+    paperId: "p1",
+    blockAnchor: "12",
+    startOffset: 5,
+    endOffset: 5,
+    quote: "x",
+  });
+  expect(r.success).toBe(false);
+});
+
+test("schema rejects a quote that is too long", () => {
+  const r = highlightInputSchema.safeParse({
+    paperId: "p1",
+    blockAnchor: "12",
+    startOffset: 0,
+    endOffset: 1,
+    quote: "x".repeat(1001),
+  });
+  expect(r.success).toBe(false);
+});
+
+test("schema accepts a valid input with an optional note", () => {
+  const r = highlightInputSchema.safeParse({
+    paperId: "p1",
+    blockAnchor: "12",
+    startOffset: 0,
+    endOffset: 4,
+    quote: "test",
+    note: "hi",
+  });
+  expect(r.success).toBe(true);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm test highlightRow`
+Expected: FAIL — cannot find module `@/lib/db/highlightRow`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `lib/db/highlightRow.ts` (mirror the Zod import style of `lib/env.ts`):
+
+```ts
+import { z } from "zod";
+import type { Highlight } from "@/lib/types";
+
+export const NOTE_MAX = 2000;
+export const QUOTE_MAX = 1000;
+
+/** A row of the `highlights` table as read back from Postgres. */
+export interface HighlightRow {
+  id: string;
+  paper_id: string;
+  block_anchor: string;
+  start_offset: number;
+  end_offset: number;
+  quote: string;
+  note: string | null;
+}
+
+/** The validated payload a client sends to create a highlight. */
+export const highlightInputSchema = z
+  .object({
+    paperId: z.string().min(1),
+    blockAnchor: z.string().min(1),
+    startOffset: z.number().int().nonnegative(),
+    endOffset: z.number().int().nonnegative(),
+    quote: z.string().min(1).max(QUOTE_MAX),
+    note: z.string().max(NOTE_MAX).nullable().optional(),
+  })
+  .refine((v) => v.endOffset > v.startOffset, {
+    message: "endOffset must be greater than startOffset",
+    path: ["endOffset"],
+  });
+
+export type HighlightInput = z.infer<typeof highlightInputSchema>;
+
+/** Map a DB row to the app-facing Highlight shape. */
+export function rowToHighlight(row: HighlightRow): Highlight {
+  return {
+    id: row.id,
+    paperId: row.paper_id,
+    blockAnchor: row.block_anchor,
+    startOffset: row.start_offset,
+    endOffset: row.end_offset,
+    quote: row.quote,
+    note: row.note,
+  };
+}
+
+/** Build the insert payload for a new highlight row. */
+export function highlightInsert(userId: string, input: HighlightInput) {
+  return {
+    user_id: userId,
+    paper_id: input.paperId,
+    block_anchor: input.blockAnchor,
+    start_offset: input.startOffset,
+    end_offset: input.endOffset,
+    quote: input.quote,
+    note: input.note ?? null,
+  };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm test highlightRow`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/db/highlightRow.ts tests/db/highlightRow.test.ts
+git commit -m "feat(highlights): row mappers + zod input schema"  # (+ trailers)
+```
+
+---
+
+## Task 3: Pure offset math (`lib/reader/highlightRange.ts` — part 1)
+
+**Files:**
+- Create: `lib/reader/highlightRange.ts`
+- Test: `tests/reader/highlightRange.test.ts`
+
+**Interfaces:**
+- Produces:
+  - `absoluteOffset(nodeLengths: number[], nodeIndex: number, offsetInNode: number): number`
+  - `interface WrapSpan { nodeIndex: number; from: number; to: number }`
+  - `rangesToWrap(nodeLengths: number[], start: number, end: number): WrapSpan[]`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/reader/highlightRange.test.ts`:
+
+```ts
+import { test, expect } from "vitest";
+import { absoluteOffset, rangesToWrap } from "@/lib/reader/highlightRange";
+
+test("absoluteOffset sums prior node lengths plus the in-node offset", () => {
+  expect(absoluteOffset([5, 3, 8], 0, 2)).toBe(2);
+  expect(absoluteOffset([5, 3, 8], 1, 1)).toBe(6); // 5 + 1
+  expect(absoluteOffset([5, 3, 8], 2, 4)).toBe(12); // 5 + 3 + 4
+});
+
+test("rangesToWrap covers a single node", () => {
+  expect(rangesToWrap([10], 2, 6)).toEqual([{ nodeIndex: 0, from: 2, to: 6 }]);
+});
+
+test("rangesToWrap splits a range across multiple nodes", () => {
+  // nodes: [0..5) [5..8) [8..16); range [3, 12)
+  expect(rangesToWrap([5, 3, 8], 3, 12)).toEqual([
+    { nodeIndex: 0, from: 3, to: 5 },
+    { nodeIndex: 1, from: 0, to: 3 },
+    { nodeIndex: 2, from: 0, to: 4 },
+  ]);
+});
+
+test("rangesToWrap omits nodes fully outside the range", () => {
+  expect(rangesToWrap([4, 4, 4], 5, 7)).toEqual([{ nodeIndex: 1, from: 1, to: 3 }]);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm test highlightRange`
+Expected: FAIL — cannot find module `@/lib/reader/highlightRange`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `lib/reader/highlightRange.ts`:
+
+```ts
+/**
+ * Highlight anchoring for the HTML reader. Offsets are character indices into a
+ * block's normalized textContent (the in-order concatenation of its descendant
+ * text nodes). The same text-node walk is used at creation and at render time,
+ * so offsets stay consistent across inline markup (<em>, <a>, <code>).
+ */
+
+/** Sum of text-node lengths before nodeIndex, plus the in-node offset. */
+export function absoluteOffset(
+  nodeLengths: number[],
+  nodeIndex: number,
+  offsetInNode: number,
+): number {
+  let total = 0;
+  for (let i = 0; i < nodeIndex; i++) total += nodeLengths[i] ?? 0;
+  return total + offsetInNode;
+}
+
+export interface WrapSpan {
+  nodeIndex: number;
+  from: number;
+  to: number;
+}
+
+/**
+ * Given a block's text-node lengths (document order) and an absolute [start, end)
+ * range over their concatenation, return the per-node sub-spans the range covers.
+ * Nodes fully outside the range are omitted; the offsets in each span are local
+ * to that node.
+ */
+export function rangesToWrap(nodeLengths: number[], start: number, end: number): WrapSpan[] {
+  const spans: WrapSpan[] = [];
+  let pos = 0;
+  for (let i = 0; i < nodeLengths.length; i++) {
+    const len = nodeLengths[i] ?? 0;
+    const nodeStart = pos;
+    const nodeEnd = pos + len;
+    const from = Math.max(start, nodeStart);
+    const to = Math.min(end, nodeEnd);
+    if (to > from) spans.push({ nodeIndex: i, from: from - nodeStart, to: to - nodeStart });
+    pos = nodeEnd;
+  }
+  return spans;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm test highlightRange`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/reader/highlightRange.ts tests/reader/highlightRange.test.ts
+git commit -m "feat(highlights): pure offset math (absoluteOffset, rangesToWrap)"  # (+ trailers)
+```
+
+---
+
+## Task 4: DOM adapters (`lib/reader/highlightRange.ts` — part 2)
+
+**Files:**
+- Modify: `lib/reader/highlightRange.ts` (append DOM helpers)
+- Test: `tests/reader/highlightRange.test.ts` (append jsdom cases)
+
+**Interfaces:**
+- Consumes: `absoluteOffset`, `rangesToWrap`, `WrapSpan` (Task 3); `Highlight` (Task 1).
+- Produces:
+  - `textNodesOf(block: Element): Text[]`
+  - `offsetsFromSelection(block: Element, range: Range): { start: number; end: number; quote: string } | null`
+  - `interface DecorateTarget { id: string; startOffset: number; endOffset: number; quote: string; hasNote: boolean }`
+  - `MARK_CLASS = "pd-highlight"` (exported const)
+  - `decorateBlock(block: Element, highlights: DecorateTarget[], onClick: (id: string) => void): void`
+  - `clearHighlights(root: Element): void`
+
+- [ ] **Step 1: Write the failing test (append to the existing file)**
+
+Append to `tests/reader/highlightRange.test.ts`:
+
+```ts
+import {
+  offsetsFromSelection,
+  decorateBlock,
+  clearHighlights,
+  MARK_CLASS,
+  type DecorateTarget,
+} from "@/lib/reader/highlightRange";
+
+function block(html: string): HTMLElement {
+  const el = document.createElement("div");
+  el.setAttribute("data-blk", "0");
+  el.innerHTML = html;
+  document.body.appendChild(el);
+  return el;
+}
+
+function selectRange(node: Node, start: number, end: number): Range {
+  const range = document.createRange();
+  range.setStart(node, start);
+  range.setEnd(node, end);
+  return range;
+}
+
+test("offsetsFromSelection returns offsets + quote across inline markup", () => {
+  // textContent = "Diffusion models are great"  (em wraps "models")
+  const el = block("Diffusion <em>models</em> are great");
+  const emText = el.querySelector("em")!.firstChild!; // "models"
+  const r = selectRange(emText, 0, 6); // "models"
+  expect(offsetsFromSelection(el, r)).toEqual({ start: 10, end: 16, quote: "models" });
+});
+
+test("offsetsFromSelection returns null for a collapsed selection", () => {
+  const el = block("hello world");
+  const r = selectRange(el.firstChild!, 3, 3);
+  expect(offsetsFromSelection(el, r)).toBeNull();
+});
+
+test("offsetsFromSelection clamps an end that runs past the block", () => {
+  const el = block("abcdef");
+  const r = document.createRange();
+  r.setStart(el.firstChild!, 2);
+  r.setEndAfter(el); // end outside the block's text nodes
+  const res = offsetsFromSelection(el, r);
+  expect(res).toEqual({ start: 2, end: 6, quote: "cdef" });
+});
+
+test("decorateBlock wraps the range in a mark and skips drifted quotes", () => {
+  const el = block("Diffusion models are great");
+  const targets: DecorateTarget[] = [
+    { id: "h1", startOffset: 10, endOffset: 16, quote: "models", hasNote: true },
+    { id: "h2", startOffset: 0, endOffset: 9, quote: "STALE!!!", hasNote: false }, // drift → skip
+  ];
+  const clicked: string[] = [];
+  decorateBlock(el, targets, (id) => clicked.push(id));
+
+  const marks = el.querySelectorAll(`mark.${MARK_CLASS}`);
+  expect(marks.length).toBe(1);
+  expect(marks[0].textContent).toBe("models");
+  expect((marks[0] as HTMLElement).dataset.hlId).toBe("h1");
+  expect((marks[0] as HTMLElement).dataset.hlNote).toBe("1");
+
+  (marks[0] as HTMLElement).click();
+  expect(clicked).toEqual(["h1"]);
+});
+
+test("clearHighlights removes marks and restores plain text", () => {
+  const el = block("Diffusion models are great");
+  decorateBlock(el, [{ id: "h1", startOffset: 10, endOffset: 16, quote: "models", hasNote: false }], () => {});
+  expect(el.querySelectorAll(`mark.${MARK_CLASS}`).length).toBe(1);
+  clearHighlights(el);
+  expect(el.querySelectorAll(`mark.${MARK_CLASS}`).length).toBe(0);
+  expect(el.textContent).toBe("Diffusion models are great");
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm test highlightRange`
+Expected: FAIL — `offsetsFromSelection`/`decorateBlock`/`clearHighlights`/`MARK_CLASS` not exported.
+
+- [ ] **Step 3: Write the implementation (append to `lib/reader/highlightRange.ts`)**
+
+```ts
+export const MARK_CLASS = "pd-highlight";
+
+/** Ordered descendant text nodes of a block (includes those inside <math>). */
+export function textNodesOf(block: Element): Text[] {
+  const walker = document.createTreeWalker(block, NodeFilter.SHOW_TEXT);
+  const nodes: Text[] = [];
+  for (let n = walker.nextNode(); n; n = walker.nextNode()) nodes.push(n as Text);
+  return nodes;
+}
+
+function isInsideMath(node: Node): boolean {
+  let el: Element | null = node.parentElement;
+  while (el) {
+    if (el.tagName.toLowerCase() === "math") return true;
+    el = el.parentElement;
+  }
+  return false;
+}
+
+/**
+ * Compute {start, end, quote} for a selection Range, as offsets into the block's
+ * textContent, clamped to the block. Returns null when the selection is collapsed,
+ * starts outside the block, has non-text endpoints, or its endpoints are inside a
+ * <math> subtree.
+ */
+export function offsetsFromSelection(
+  block: Element,
+  range: Range,
+): { start: number; end: number; quote: string } | null {
+  if (range.collapsed) return null;
+  const nodes = textNodesOf(block);
+  if (nodes.length === 0) return null;
+  const lengths = nodes.map((t) => t.data.length);
+
+  const startIdx = nodes.indexOf(range.startContainer as Text);
+  if (startIdx === -1 || isInsideMath(nodes[startIdx])) return null;
+  const start = absoluteOffset(lengths, startIdx, range.startOffset);
+
+  const total = lengths.reduce((a, b) => a + b, 0);
+  const endIdx = nodes.indexOf(range.endContainer as Text);
+  let end: number;
+  if (endIdx === -1) {
+    end = total; // selection runs past this block — clamp to its end
+  } else {
+    if (isInsideMath(nodes[endIdx])) return null;
+    end = absoluteOffset(lengths, endIdx, range.endOffset);
+  }
+  if (end <= start) return null;
+
+  const quote = nodes.map((t) => t.data).join("").slice(start, end);
+  if (!quote) return null;
+  return { start, end, quote };
+}
+
+export interface DecorateTarget {
+  id: string;
+  startOffset: number;
+  endOffset: number;
+  quote: string;
+  hasNote: boolean;
+}
+
+/**
+ * Paint each highlight as a <mark> inside the block. Recomputes text nodes per
+ * highlight (so already-painted marks are accounted for), skips a highlight whose
+ * quote no longer matches the live slice (drift), and skips sub-spans inside <math>.
+ */
+export function decorateBlock(
+  block: Element,
+  highlights: DecorateTarget[],
+  onClick: (id: string) => void,
+): void {
+  for (const h of highlights) {
+    const nodes = textNodesOf(block);
+    const lengths = nodes.map((t) => t.data.length);
+    const text = nodes.map((t) => t.data).join("");
+    if (text.slice(h.startOffset, h.endOffset) !== h.quote) continue; // drift — skip
+
+    // Resolve to concrete node references BEFORE mutating; each is wrapped once,
+    // so wrapping one (which splits only that text node) never invalidates another.
+    const targets = rangesToWrap(lengths, h.startOffset, h.endOffset)
+      .map((s) => ({ node: nodes[s.nodeIndex], from: s.from, to: s.to }))
+      .filter((t) => t.node && !isInsideMath(t.node));
+    for (const t of targets) wrapTextRange(t.node, t.from, t.to, h, onClick);
+  }
+}
+
+function wrapTextRange(
+  node: Text,
+  from: number,
+  to: number,
+  h: DecorateTarget,
+  onClick: (id: string) => void,
+): void {
+  const range = document.createRange();
+  range.setStart(node, from);
+  range.setEnd(node, to);
+  const mark = document.createElement("mark");
+  mark.className = MARK_CLASS;
+  mark.dataset.hlId = h.id;
+  if (h.hasNote) mark.dataset.hlNote = "1";
+  mark.addEventListener("click", (e) => {
+    e.stopPropagation();
+    onClick(h.id);
+  });
+  range.surroundContents(mark);
+}
+
+/** Unwrap every highlight mark under root, restoring plain text. */
+export function clearHighlights(root: Element): void {
+  root.querySelectorAll(`mark.${MARK_CLASS}`).forEach((mark) => {
+    const parent = mark.parentNode;
+    if (!parent) return;
+    while (mark.firstChild) parent.insertBefore(mark.firstChild, mark);
+    parent.removeChild(mark);
+    parent.normalize(); // merge the split text nodes back together
+  });
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm test highlightRange`
+Expected: PASS (9 tests total).
+
+- [ ] **Step 5: Typecheck + commit**
+
+Run: `pnpm typecheck`
+Expected: no errors.
+
+```bash
+git add lib/reader/highlightRange.ts tests/reader/highlightRange.test.ts
+git commit -m "feat(highlights): DOM adapters — selection offsets, decorate, clear"  # (+ trailers)
+```
+
+---
+
+## Task 5: Server actions (`app/actions/highlights.ts`)
+
+**Files:**
+- Create: `app/actions/highlights.ts`
+- Test: `tests/actions/highlights.test.ts`
+
+**Interfaces:**
+- Consumes: `serverClient` (`@/lib/db/server`), `currentUser` (`@/lib/auth`), `highlightInputSchema`/`highlightInsert`/`rowToHighlight`/`NOTE_MAX`/`HighlightInput`/`HighlightRow` (Task 2), `Highlight` (Task 1).
+- Produces:
+  - `loadHighlights(paperId: string): Promise<Highlight[]>`
+  - `createHighlight(input: HighlightInput): Promise<Highlight | null>`
+  - `updateHighlightNote(id: string, note: string | null): Promise<void>`
+  - `deleteHighlight(id: string): Promise<void>`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/actions/highlights.test.ts` (chainable Supabase mock, mirroring `tests/actions/star.test.ts`):
+
+```ts
+import { test, expect, vi, beforeEach } from "vitest";
+import type { User } from "@supabase/supabase-js";
+
+const mocks = vi.hoisted(() => {
+  // select(...).eq(...).eq(...).order(...) -> { data, error }
+  const order = vi.fn(async () => ({ data: [] as unknown[], error: null }));
+  const selectEq2 = vi.fn(() => ({ order }));
+  const selectEq1 = vi.fn(() => ({ eq: selectEq2 }));
+  const select = vi.fn(() => ({ eq: selectEq1 }));
+  // insert(...).select(...).single() -> { data, error }
+  const single = vi.fn(async () => ({ data: null as unknown, error: null as unknown }));
+  const insertSelect = vi.fn(() => ({ single }));
+  const insert = vi.fn(() => ({ select: insertSelect }));
+  // update(...).eq(...).eq(...) -> { error }
+  const updateEq2 = vi.fn(async () => ({ error: null }));
+  const updateEq1 = vi.fn(() => ({ eq: updateEq2 }));
+  const update = vi.fn(() => ({ eq: updateEq1 }));
+  // delete().eq(...).eq(...) -> { error }
+  const deleteEq2 = vi.fn(async () => ({ error: null }));
+  const deleteEq1 = vi.fn(() => ({ eq: deleteEq2 }));
+  const del = vi.fn(() => ({ eq: deleteEq1 }));
+
+  const from = vi.fn(() => ({ select, insert, update, delete: del }));
+  return {
+    order, single, insert, insertSelect, update, updateEq2, del, deleteEq2, from,
+    currentUser: vi.fn(async (): Promise<User | null> => null),
+  };
+});
+
+vi.mock("@/lib/auth", () => ({ currentUser: mocks.currentUser }));
+vi.mock("@/lib/db/server", () => ({ serverClient: async () => ({ from: mocks.from }) }));
+
+import {
+  loadHighlights,
+  createHighlight,
+  deleteHighlight,
+} from "@/app/actions/highlights";
+
+const USER = { id: "user-1" } as User;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.currentUser.mockResolvedValue(USER);
+});
+
+test("loadHighlights returns [] and skips the DB when signed out", async () => {
+  mocks.currentUser.mockResolvedValue(null);
+  expect(await loadHighlights("p1")).toEqual([]);
+  expect(mocks.from).not.toHaveBeenCalled();
+});
+
+test("loadHighlights maps returned rows to the app shape", async () => {
+  mocks.order.mockResolvedValue({
+    data: [
+      { id: "h1", paper_id: "p1", block_anchor: "2", start_offset: 0, end_offset: 4, quote: "test", note: null },
+    ],
+    error: null,
+  });
+  const result = await loadHighlights("p1");
+  expect(result).toEqual([
+    { id: "h1", paperId: "p1", blockAnchor: "2", startOffset: 0, endOffset: 4, quote: "test", note: null },
+  ]);
+});
+
+test("createHighlight returns null and skips insert on invalid input", async () => {
+  const result = await createHighlight({
+    paperId: "p1", blockAnchor: "2", startOffset: 5, endOffset: 5, quote: "x", // end <= start
+  });
+  expect(result).toBeNull();
+  expect(mocks.insert).not.toHaveBeenCalled();
+});
+
+test("createHighlight inserts and returns the mapped row on success", async () => {
+  mocks.single.mockResolvedValue({
+    data: { id: "h9", paper_id: "p1", block_anchor: "2", start_offset: 0, end_offset: 4, quote: "test", note: null },
+    error: null,
+  });
+  const result = await createHighlight({
+    paperId: "p1", blockAnchor: "2", startOffset: 0, endOffset: 4, quote: "test",
+  });
+  expect(result).toEqual({
+    id: "h9", paperId: "p1", blockAnchor: "2", startOffset: 0, endOffset: 4, quote: "test", note: null,
+  });
+  expect(mocks.insert).toHaveBeenCalledWith({
+    user_id: "user-1", paper_id: "p1", block_anchor: "2", start_offset: 0, end_offset: 4, quote: "test", note: null,
+  });
+});
+
+test("deleteHighlight is a no-op when signed out", async () => {
+  mocks.currentUser.mockResolvedValue(null);
+  await deleteHighlight("h1");
+  expect(mocks.from).not.toHaveBeenCalled();
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm test actions/highlights`
+Expected: FAIL — cannot find module `@/app/actions/highlights`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `app/actions/highlights.ts`:
+
+```ts
+"use server";
+
+import { serverClient } from "@/lib/db/server";
+import { currentUser } from "@/lib/auth";
+import type { Highlight } from "@/lib/types";
+import {
+  highlightInputSchema,
+  highlightInsert,
+  rowToHighlight,
+  NOTE_MAX,
+  type HighlightInput,
+  type HighlightRow,
+} from "@/lib/db/highlightRow";
+
+const HL_COLS = "id, paper_id, block_anchor, start_offset, end_offset, quote, note";
+
+/** All of the current user's highlights for a paper (oldest first). Empty when signed out. */
+export async function loadHighlights(paperId: string): Promise<Highlight[]> {
+  const user = await currentUser();
+  if (!user) return [];
+  const db = await serverClient();
+  const { data } = await db
+    .from("highlights")
+    .select(HL_COLS)
+    .eq("user_id", user.id)
+    .eq("paper_id", paperId)
+    .order("created_at", { ascending: true });
+  return ((data as HighlightRow[] | null) ?? []).map(rowToHighlight);
+}
+
+/** Create a highlight; returns the saved row (with id) for optimistic painting, or null. */
+export async function createHighlight(input: HighlightInput): Promise<Highlight | null> {
+  const user = await currentUser();
+  if (!user) return null;
+  const parsed = highlightInputSchema.safeParse(input);
+  if (!parsed.success) return null;
+  const db = await serverClient();
+  const { data, error } = await db
+    .from("highlights")
+    .insert(highlightInsert(user.id, parsed.data))
+    .select(HL_COLS)
+    .single();
+  if (error || !data) return null;
+  return rowToHighlight(data as HighlightRow);
+}
+
+/** Set (or clear) the note on a highlight the user owns. */
+export async function updateHighlightNote(id: string, note: string | null): Promise<void> {
+  const user = await currentUser();
+  if (!user) return;
+  const capped = note && note.length > NOTE_MAX ? note.slice(0, NOTE_MAX) : note;
+  const db = await serverClient();
+  await db
+    .from("highlights")
+    .update({ note: capped ?? null, updated_at: new Date().toISOString() })
+    .eq("id", id)
+    .eq("user_id", user.id);
+}
+
+/** Delete a highlight the user owns. */
+export async function deleteHighlight(id: string): Promise<void> {
+  const user = await currentUser();
+  if (!user) return;
+  const db = await serverClient();
+  await db.from("highlights").delete().eq("id", id).eq("user_id", user.id);
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm test actions/highlights`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/actions/highlights.ts tests/actions/highlights.test.ts
+git commit -m "feat(highlights): server actions (load/create/updateNote/delete)"  # (+ trailers)
+```
+
+---
+
+## Task 6: `HighlightLayer` component
+
+**Files:**
+- Create: `components/HighlightLayer.tsx`
+- Test: `tests/components/HighlightLayer.test.tsx`
+
+**Interfaces:**
+- Consumes: `offsetsFromSelection`, `decorateBlock`, `clearHighlights`, `MARK_CLASS`, `DecorateTarget` (Task 4); `createHighlight`, `updateHighlightNote`, `deleteHighlight` (Task 5); `Highlight` (Task 1); `Button` (`@/components/ui`).
+- Produces: `HighlightLayer({ paperId, containerRef, initialHighlights }): JSX.Element` where `containerRef: React.RefObject<HTMLDivElement | null>`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/components/HighlightLayer.test.tsx`:
+
+```tsx
+import { test, expect, vi, beforeEach } from "vitest";
+import { useRef } from "react";
+import { render, screen, fireEvent, act } from "@testing-library/react";
+
+const actions = vi.hoisted(() => ({
+  createHighlight: vi.fn(),
+  updateHighlightNote: vi.fn(async () => {}),
+  deleteHighlight: vi.fn(async () => {}),
+}));
+vi.mock("@/app/actions/highlights", () => actions);
+
+import { HighlightLayer } from "@/components/HighlightLayer";
+import type { Highlight } from "@/lib/types";
+
+const HTML = `<p data-blk="0">Diffusion models are great</p>`;
+
+function Harness({ initial }: { initial: Highlight[] }) {
+  const ref = useRef<HTMLDivElement>(null);
+  return (
+    <div>
+      <div ref={ref} dangerouslySetInnerHTML={{ __html: HTML }} />
+      <HighlightLayer paperId="p1" containerRef={ref} initialHighlights={initial} />
+    </div>
+  );
+}
+
+function selectText(container: HTMLElement, from: number, to: number) {
+  const p = container.querySelector('[data-blk="0"]')!;
+  const textNode = p.firstChild!;
+  const range = document.createRange();
+  range.setStart(textNode, from);
+  range.setEnd(textNode, to);
+  const sel = window.getSelection()!;
+  sel.removeAllRanges();
+  sel.addRange(range);
+  fireEvent.mouseUp(document);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+test("an initial highlight is painted as a mark on mount", () => {
+  const { container } = render(
+    <Harness initial={[{ id: "h1", paperId: "p1", blockAnchor: "0", startOffset: 10, endOffset: 16, quote: "models", note: "hi" }]} />,
+  );
+  const mark = container.querySelector("mark.pd-highlight");
+  expect(mark).not.toBeNull();
+  expect(mark!.textContent).toBe("models");
+});
+
+test("selecting text shows the Highlight button; clicking it creates and paints a highlight", async () => {
+  actions.createHighlight.mockResolvedValue({
+    id: "h2", paperId: "p1", blockAnchor: "0", startOffset: 10, endOffset: 16, quote: "models", note: null,
+  });
+  const { container } = render(<Harness initial={[]} />);
+
+  selectText(container, 10, 16); // "models"
+  const btn = await screen.findByRole("button", { name: /highlight/i });
+
+  await act(async () => {
+    fireEvent.click(btn);
+  });
+
+  expect(actions.createHighlight).toHaveBeenCalledWith({
+    paperId: "p1", blockAnchor: "0", startOffset: 10, endOffset: 16, quote: "models", note: null,
+  });
+  expect(container.querySelector('mark.pd-highlight[data-hl-id="h2"]')).not.toBeNull();
+});
+
+test("clicking an existing mark opens the note editor; saving calls updateHighlightNote", async () => {
+  const { container } = render(
+    <Harness initial={[{ id: "h1", paperId: "p1", blockAnchor: "0", startOffset: 10, endOffset: 16, quote: "models", note: null }]} />,
+  );
+  const mark = container.querySelector("mark.pd-highlight")!;
+
+  await act(async () => {
+    fireEvent.click(mark);
+  });
+  const textarea = await screen.findByRole("textbox");
+  fireEvent.change(textarea, { target: { value: "key idea" } });
+
+  await act(async () => {
+    fireEvent.click(screen.getByRole("button", { name: /save/i }));
+  });
+  expect(actions.updateHighlightNote).toHaveBeenCalledWith("h1", "key idea");
+});
+
+test("deleting from the editor calls deleteHighlight and removes the mark", async () => {
+  const { container } = render(
+    <Harness initial={[{ id: "h1", paperId: "p1", blockAnchor: "0", startOffset: 10, endOffset: 16, quote: "models", note: null }]} />,
+  );
+  await act(async () => {
+    fireEvent.click(container.querySelector("mark.pd-highlight")!);
+  });
+  await act(async () => {
+    fireEvent.click(screen.getByRole("button", { name: /delete/i }));
+  });
+  expect(actions.deleteHighlight).toHaveBeenCalledWith("h1");
+  expect(container.querySelector("mark.pd-highlight")).toBeNull();
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm test HighlightLayer`
+Expected: FAIL — cannot find module `@/components/HighlightLayer`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `components/HighlightLayer.tsx`:
+
+```tsx
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { RefObject } from "react";
+import { createHighlight, deleteHighlight, updateHighlightNote } from "@/app/actions/highlights";
+import {
+  offsetsFromSelection,
+  decorateBlock,
+  clearHighlights,
+  MARK_CLASS,
+  type DecorateTarget,
+} from "@/lib/reader/highlightRange";
+import { Button } from "@/components/ui";
+import type { Highlight } from "@/lib/types";
+
+type Pending = { x: number; y: number; blockAnchor: string; start: number; end: number; quote: string };
+type Editing = { id: string; x: number; y: number };
+
+export function HighlightLayer({
+  paperId,
+  containerRef,
+  initialHighlights,
+}: {
+  paperId: string;
+  containerRef: RefObject<HTMLDivElement | null>;
+  initialHighlights: Highlight[];
+}) {
+  const [highlights, setHighlights] = useState<Highlight[]>(initialHighlights);
+  const [pending, setPending] = useState<Pending | null>(null);
+  const [editing, setEditing] = useState<Editing | null>(null);
+  const [noteDraft, setNoteDraft] = useState("");
+
+  // Keep a ref so click handlers bound into the DOM read current highlights
+  // without changing identity (which would thrash the repaint effect).
+  const hlRef = useRef(highlights);
+  useEffect(() => {
+    hlRef.current = highlights;
+  }, [highlights]);
+
+  const openEditor = useCallback(
+    (id: string) => {
+      const root = containerRef.current;
+      const mark = root?.querySelector<HTMLElement>(`mark.${MARK_CLASS}[data-hl-id="${id}"]`);
+      const rect = mark?.getBoundingClientRect();
+      const h = hlRef.current.find((x) => x.id === id);
+      setEditing({ id, x: rect?.left ?? 0, y: rect?.bottom ?? 0 });
+      setNoteDraft(h?.note ?? "");
+    },
+    [containerRef],
+  );
+
+  // (Re)paint marks whenever the highlight set changes.
+  useEffect(() => {
+    const root = containerRef.current;
+    if (!root) return;
+    clearHighlights(root);
+    const byBlock = new Map<string, DecorateTarget[]>();
+    for (const h of highlights) {
+      const target: DecorateTarget = {
+        id: h.id,
+        startOffset: h.startOffset,
+        endOffset: h.endOffset,
+        quote: h.quote,
+        hasNote: !!h.note,
+      };
+      const arr = byBlock.get(h.blockAnchor) ?? [];
+      arr.push(target);
+      byBlock.set(h.blockAnchor, arr);
+    }
+    for (const [blk, targets] of byBlock) {
+      const block = root.querySelector(`[data-blk="${blk}"]`);
+      if (block) decorateBlock(block, targets, openEditor);
+    }
+    return () => clearHighlights(root);
+  }, [highlights, containerRef, openEditor]);
+
+  // Show the "Highlight" button when a fresh selection sits inside one block.
+  useEffect(() => {
+    function onMouseUp() {
+      const root = containerRef.current;
+      const sel = window.getSelection();
+      if (!root || !sel || sel.isCollapsed || sel.rangeCount === 0) {
+        setPending(null);
+        return;
+      }
+      const range = sel.getRangeAt(0);
+      const block = (range.startContainer.parentElement ?? null)?.closest("[data-blk]");
+      if (!block || !root.contains(block)) {
+        setPending(null);
+        return;
+      }
+      // No overlaps in v1: ignore selections that touch an existing mark.
+      if (range.cloneContents().querySelector(`mark.${MARK_CLASS}`)) {
+        setPending(null);
+        return;
+      }
+      const offsets = offsetsFromSelection(block, range);
+      if (!offsets) {
+        setPending(null);
+        return;
+      }
+      const rect = range.getBoundingClientRect();
+      setPending({
+        x: rect.left + rect.width / 2,
+        y: rect.top,
+        blockAnchor: block.getAttribute("data-blk") ?? "",
+        start: offsets.start,
+        end: offsets.end,
+        quote: offsets.quote,
+      });
+    }
+    document.addEventListener("mouseup", onMouseUp);
+    return () => document.removeEventListener("mouseup", onMouseUp);
+  }, [containerRef]);
+
+  async function confirmHighlight() {
+    if (!pending) return;
+    const created = await createHighlight({
+      paperId,
+      blockAnchor: pending.blockAnchor,
+      startOffset: pending.start,
+      endOffset: pending.end,
+      quote: pending.quote,
+      note: null,
+    });
+    setPending(null);
+    window.getSelection()?.removeAllRanges();
+    if (created) setHighlights((hs) => [...hs, created]);
+  }
+
+  async function saveNote() {
+    if (!editing) return;
+    const note = noteDraft.trim() || null;
+    await updateHighlightNote(editing.id, note);
+    setHighlights((hs) => hs.map((h) => (h.id === editing.id ? { ...h, note } : h)));
+    setEditing(null);
+  }
+
+  async function removeHighlight() {
+    if (!editing) return;
+    await deleteHighlight(editing.id);
+    setHighlights((hs) => hs.filter((h) => h.id !== editing.id));
+    setEditing(null);
+  }
+
+  return (
+    <>
+      {pending && (
+        <div
+          className="pd-enter fixed z-30 -translate-x-1/2 -translate-y-full pb-2"
+          style={{ left: pending.x, top: pending.y }}
+        >
+          <Button variant="primary" className="h-8 px-3 text-xs shadow-md" onClick={confirmHighlight}>
+            Highlight
+          </Button>
+        </div>
+      )}
+
+      {editing && (
+        <div
+          className="pd-enter fixed z-30 w-72 rounded-xl border border-line bg-card p-3 shadow-lg"
+          style={{ left: editing.x, top: editing.y + 6 }}
+        >
+          <textarea
+            aria-label="Note"
+            className="h-24 w-full resize-none rounded-md border border-line bg-background p-2 text-sm text-ink focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/50"
+            placeholder="Add a note…"
+            value={noteDraft}
+            onChange={(e) => setNoteDraft(e.target.value)}
+          />
+          <div className="mt-2 flex items-center justify-between">
+            <button
+              type="button"
+              onClick={removeHighlight}
+              className="text-xs font-medium text-danger hover:underline"
+            >
+              Delete
+            </button>
+            <div className="flex gap-2">
+              <Button variant="ghost" className="h-8 px-3 text-xs" onClick={() => setEditing(null)}>
+                Cancel
+              </Button>
+              <Button variant="primary" className="h-8 px-3 text-xs" onClick={saveNote}>
+                Save
+              </Button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm test HighlightLayer`
+Expected: PASS (4 tests).
+
+> If `range.getBoundingClientRect`/`cloneContents` behave oddly under jsdom, the tests above only rely on element presence (not pixel positions), so they remain valid. Do not loosen an assertion to make a real failure pass — debug the component instead.
+
+- [ ] **Step 5: Typecheck + commit**
+
+Run: `pnpm typecheck`
+Expected: no errors.
+
+```bash
+git add components/HighlightLayer.tsx tests/components/HighlightLayer.test.tsx
+git commit -m "feat(highlights): HighlightLayer — selection toolbar, decoration, note popover"  # (+ trailers)
+```
+
+---
+
+## Task 7: Wire into the reader + styles
+
+**Files:**
+- Modify: `components/HtmlReader.tsx` (add `initialHighlights` prop + mount `HighlightLayer`)
+- Modify: `components/ReaderView.tsx` (thread `initialHighlights`)
+- Modify: `app/reader/[id]/page.tsx` (load highlights server-side)
+- Modify: `app/globals.css` (`.pd-highlight` styles + token)
+- Modify: `tests/components/HtmlReader.test.tsx` (mock highlights actions + integration assertion)
+
+**Interfaces:**
+- Consumes: `HighlightLayer` (Task 6), `loadHighlights` (Task 5), `Highlight` (Task 1).
+- Produces: `HtmlReader` and `ReaderView` both accept `initialHighlights?: Highlight[]` (default `[]`).
+
+- [ ] **Step 1: Update the HtmlReader test (add mock + integration assertion)**
+
+In `tests/components/HtmlReader.test.tsx`, after the existing `vi.mock("@/app/actions/progress", …)` line, add:
+
+```ts
+vi.mock("@/app/actions/highlights", () => ({
+  loadHighlights: vi.fn(async () => []),
+  createHighlight: vi.fn(),
+  updateHighlightNote: vi.fn(async () => {}),
+  deleteHighlight: vi.fn(async () => {}),
+}));
+```
+
+Then append a new test:
+
+```ts
+test("paints an initial highlight passed to the reader", () => {
+  const { container } = render(
+    <HtmlReader
+      paperId="p1"
+      html={HTML}
+      initialProgress={null}
+      initialHighlights={[
+        { id: "h1", paperId: "p1", blockAnchor: "1", startOffset: 0, endOffset: 4, quote: "Beta", note: null },
+      ]}
+    />,
+  );
+  expect(container.querySelector('mark.pd-highlight[data-hl-id="h1"]')?.textContent).toBe("Beta");
+});
+```
+
+- [ ] **Step 2: Run the test to verify the new case fails**
+
+Run: `pnpm test HtmlReader`
+Expected: FAIL — `HtmlReader` does not accept `initialHighlights` / no mark rendered.
+
+- [ ] **Step 3: Wire `HighlightLayer` into `HtmlReader`**
+
+In `components/HtmlReader.tsx`:
+
+Add imports near the top:
+
+```tsx
+import { HighlightLayer } from "@/components/HighlightLayer";
+import type { ProgressRow, Highlight } from "@/lib/types";
+```
+
+(Replace the existing `import type { ProgressRow } from "@/lib/types";` line with the combined import above.)
+
+Add the prop (default `[]`) to the component signature:
+
+```tsx
+export function HtmlReader({
+  paperId,
+  html,
+  initialProgress,
+  initialHighlights = [],
+}: {
+  paperId: string;
+  html: string;
+  initialProgress: ProgressRow | null;
+  initialHighlights?: Highlight[];
+}) {
+```
+
+Mount the layer inside the existing relative wrapper, right after the content `<div ref={containerRef} …/>`:
+
+```tsx
+        <div
+          ref={containerRef}
+          className="paper-html px-4 pb-28 pt-6"
+          dangerouslySetInnerHTML={content}
+        />
+        <HighlightLayer
+          paperId={paperId}
+          containerRef={containerRef}
+          initialHighlights={initialHighlights}
+        />
+```
+
+- [ ] **Step 4: Run the HtmlReader test to verify it passes**
+
+Run: `pnpm test HtmlReader`
+Expected: PASS (existing tests + the new highlight test).
+
+- [ ] **Step 5: Thread `initialHighlights` through `ReaderView`**
+
+In `components/ReaderView.tsx`:
+
+Update the type import and props:
+
+```tsx
+import type { ProgressRow, Highlight } from "@/lib/types";
+```
+
+```tsx
+export function ReaderView({
+  paperId,
+  initialProgress,
+  initialHighlights,
+}: {
+  paperId: string;
+  initialProgress: ProgressRow | null;
+  initialHighlights: Highlight[];
+}) {
+```
+
+Pass it to the HTML reader (the PDF branch is unchanged — out of scope):
+
+```tsx
+  if (payload.kind === "html") {
+    return (
+      <HtmlReader
+        paperId={paperId}
+        html={payload.html}
+        initialProgress={initialProgress}
+        initialHighlights={initialHighlights}
+      />
+    );
+  }
+```
+
+- [ ] **Step 6: Load highlights in the reader page**
+
+In `app/reader/[id]/page.tsx`:
+
+Add the import:
+
+```tsx
+import { loadHighlights } from "@/app/actions/highlights";
+```
+
+Load alongside progress and pass to `ReaderView`:
+
+```tsx
+  const progress = await loadProgress(id);
+  const highlights = await loadHighlights(id);
+```
+
+```tsx
+      <ReaderView paperId={id} initialProgress={progress} initialHighlights={highlights} />
+```
+
+- [ ] **Step 7: Add highlight styles**
+
+In `app/globals.css`, add the token to BOTH `:root` and `[data-theme="dark"]`:
+
+```css
+/* in :root */
+  --highlight-bg: rgba(217, 164, 65, 0.34);   /* translucent amber */
+  --highlight-line: rgba(217, 164, 65, 0.9);
+```
+
+```css
+/* in [data-theme="dark"] */
+  --highlight-bg: rgba(185, 138, 58, 0.40);
+  --highlight-line: rgba(185, 138, 58, 0.95);
+```
+
+Then append, after the `.paper-html` rules:
+
+```css
+/* ---- Reader: user highlights ---- */
+mark.pd-highlight {
+  background: var(--highlight-bg);
+  color: inherit;
+  border-radius: 2px;
+  padding: 0 0.5px;
+  cursor: pointer;
+  -webkit-box-decoration-break: clone;
+  box-decoration-break: clone;
+}
+/* highlights that carry a note get a subtle underline cue */
+mark.pd-highlight[data-hl-note="1"] {
+  text-decoration: underline;
+  text-decoration-color: var(--highlight-line);
+  text-underline-offset: 3px;
+}
+```
+
+- [ ] **Step 8: Full verification**
+
+Run: `pnpm typecheck && pnpm test && pnpm lint`
+Expected: typecheck clean, all tests pass, lint clean.
+
+- [ ] **Step 9: Manual smoke (optional but recommended)**
+
+Run `pnpm dev` (webpack), open a paper with an HTML reader while signed in, select a sentence → click **Highlight** → reload → the highlight persists → click it → add a note → Save → reload → underline cue shows → click → Delete.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add components/HtmlReader.tsx components/ReaderView.tsx "app/reader/[id]/page.tsx" app/globals.css tests/components/HtmlReader.test.tsx
+git commit -m "feat(highlights): wire HighlightLayer into the HTML reader + styles"  # (+ trailers)
+```
+
+---
+
+## Self-Review (completed at write time)
+
+**Spec coverage:**
+- Data model + RLS → Task 1. ✅
+- Text-offset anchoring (block + char offsets into textContent) → Tasks 3–4. ✅
+- Drift skip-paint via quote match → Task 4 (`decorateBlock`). ✅
+- Single-block clamp; null on collapsed/in-math/non-text endpoints → Task 4 (`offsetsFromSelection`). ✅
+- Server actions w/ auth guard + Zod + RLS defense-in-depth → Tasks 2, 5. ✅
+- In-reader UX: selection toolbar, click-to-edit note, delete; overlaps disallowed → Task 6. ✅
+- Logged-out path: actions return empty/null (reader route is already auth-gated) → Task 5. ✅
+- Single color + has-note cue, dark-mode token → Task 7. ✅
+- Load `initialHighlights` server-side like `initialProgress` → Task 7. ✅
+- Out of scope (PDF, cross-block, multi-color, global page, badges, export, drift recovery) → not implemented. ✅
+
+**Placeholder scan:** none — every code/test step contains complete content.
+
+**Type consistency:** `Highlight`, `HighlightRow`, `HighlightInput`, `DecorateTarget`, `WrapSpan`, `MARK_CLASS`, and all action signatures are defined once and used consistently across tasks. `initialHighlights` is the same prop name in `HtmlReader`, `ReaderView`, and the page.

--- a/docs/superpowers/specs/2026-06-23-highlights-notes-design.md
+++ b/docs/superpowers/specs/2026-06-23-highlights-notes-design.md
@@ -1,0 +1,197 @@
+# Highlights & Notes — Design (v1)
+
+**Status:** approved for planning
+**Branch:** `feat/reader-highlights-notes` (off `master`)
+**Date:** 2026-06-23
+
+## Summary
+
+Let signed-in users highlight a passage of text in the **HTML reader** and attach an
+optional note to it. Highlights render inline on re-open and are clickable to
+view/edit/delete the note. This reuses the reader's existing `data-blk` block
+anchors (already used for scroll-resume and the read-rail) as the anchoring base.
+
+## Decisions (locked)
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Granularity | **Text selection** (phrase/sentence), stored as block anchor + char offsets | What researchers expect; precise. |
+| Reader scope | **HTML reader only** | Primary reader; PDF text-layer highlighting is a separate, harder problem. |
+| Notes | **Optional note attached to a highlight** (one concept) | Simplest model that covers "highlight + comment". |
+| Cross-block selections | **Clamp to the starting block** | Keeps the data model `{block, start, end}` simple/robust. |
+| Surfacing | **In-reader only** | Self-contained v1; no new routes. |
+| Color | **Single color** | YAGNI on multi-color. |
+| Overlaps | **Disallowed at creation** | Keeps rendering simple (no nested-mark splitting). |
+| Rendering | **Client-side `<mark>` decoration** (Approach A) | Per-user data stays out of the shared `paper_content` cache; a real element makes click-to-edit-note natural; pure offset math is unit-testable. |
+
+### Approaches considered
+
+- **A — Text-offset anchoring + client-side `<mark>` decoration (CHOSEN).** Store
+  `{block_anchor, start_offset, end_offset, quote, note}`; offsets index the block's
+  normalized `textContent`. After mount, a client effect wraps `[start,end]` in a
+  `<mark>`, splitting text nodes as needed. Clicking a `<mark>` opens the note popover.
+  - *Cons:* anchors drift if a paper's sanitized HTML is regenerated — mitigated by
+    storing `quote` and skip-painting on mismatch.
+- **B — CSS Custom Highlight API (`::highlight()`), no DOM mutation.** Same anchoring
+  but paints ranges via the Highlight registry. Rejected: click-to-edit-note needs
+  manual `caretRangeFromPoint` hit-testing; newer browser support; awkward in jsdom.
+- **C — Server-side `<mark>` injection per request.** Rejected: can't serve the shared
+  cached HTML as-is (per-user post-processing), every create/delete forces a
+  re-render, and offset math on a raw tag-laden string is far hairier than over DOM
+  text nodes.
+
+## Architecture
+
+### Data model — `supabase/migrations/0006_highlights.sql`
+
+```sql
+create table if not exists highlights (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  paper_id uuid not null references papers(id) on delete cascade,
+  block_anchor text not null,      -- the data-blk value, e.g. "12"
+  start_offset int not null,       -- char index into the block's textContent
+  end_offset int not null,         -- exclusive
+  quote text not null,             -- selected text: drift detection + popover display
+  note text,                       -- optional comment (nullable)
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  check (start_offset >= 0 and end_offset > start_offset)
+);
+create index if not exists highlights_user_paper_idx on highlights (user_id, paper_id, created_at);
+
+alter table highlights enable row level security;
+drop policy if exists "highlights owner" on highlights;
+create policy "highlights owner" on highlights
+  for all using (auth.uid() = user_id) with check (auth.uid() = user_id);
+```
+
+Apply via Supabase MCP (timestamp version in the ledger) **and** commit as the
+`0006_highlights.sql` repo file. `if not exists` / `drop policy if exists` keep
+re-apply idempotent, consistent with the existing ledger-vs-file-numbers split.
+
+### Anchor core — `lib/reader/highlightRange.ts`
+
+Offsets are character indices into a block's normalized `textContent` (the in-order
+concatenation of its descendant text nodes). Creation and rendering both use the same
+text-node walk, so they stay consistent across inline markup (`<em>`, `<a>`, `<code>`).
+
+**Pure (no DOM — unit tested):**
+- `absoluteOffset(nodeLengths: number[], nodeIndex: number, offsetInNode: number): number`
+- `rangesToWrap(nodeLengths: number[], start: number, end: number): { nodeIndex: number; from: number; to: number }[]`
+  — the text-node sub-spans that the `[start,end]` range covers.
+
+**Thin DOM adapters (jsdom tested):**
+- `textNodesOf(block: Element): Text[]` — ordered descendant text nodes (TreeWalker).
+- `offsetsFromSelection(block: Element, range: Range): { start: number; end: number } | null`
+  — computes offsets via `absoluteOffset`; clamps the end to the block's length;
+  returns `null` if the selection is collapsed/whitespace-only or starts/ends inside a
+  `<math>` subtree.
+- `decorateBlock(block: Element, highlights: Highlight[], onClick): void` — applies
+  `rangesToWrap` and wraps each sub-span in
+  `<mark class="pd-highlight" data-hl-id="…">`. **Validates `quote` against the live
+  text slice and skips painting on mismatch** (drift-safe). Skips any sub-span whose
+  text node is inside a `<math>` ancestor so equation layout isn't broken.
+
+### Server actions — `app/actions/highlights.ts` + `lib/db/highlightRow.ts`
+
+Same shape as `app/actions/progress.ts`: `"use server"` → `currentUser()` guard →
+`serverClient()`; RLS double-enforces ownership. Inputs validated with `zod`
+(non-negative int offsets, `end > start`, quote/note length caps).
+
+- `loadHighlights(paperId: string): Promise<Highlight[]>` — current user's highlights
+  for the paper (empty array when logged out).
+- `createHighlight(input): Promise<Highlight | null>` — insert; returns the row
+  (with `id`) so the client can paint optimistically.
+- `updateHighlightNote(id: string, note: string | null): Promise<void>`
+- `deleteHighlight(id: string): Promise<void>`
+
+`lib/db/highlightRow.ts` holds the row⇄`Highlight` mappers + the zod schema (mirrors
+`lib/db/progressRow.ts`). New `Highlight` type added to `lib/types.ts`:
+
+```ts
+export interface Highlight {
+  id: string;
+  paperId: string;
+  blockAnchor: string;
+  startOffset: number;
+  endOffset: number;
+  quote: string;
+  note: string | null;
+}
+```
+
+### Reader integration — `components/HighlightLayer.tsx`
+
+`HtmlReader` already owns `containerRef`. A new `HighlightLayer` child keeps
+`HtmlReader` lean and owns the highlight UX:
+
+- On a non-collapsed selection inside a `[data-blk]`, show a floating **"Highlight"
+  button** near the selection. Suppressed when the selection intersects an existing
+  `<mark>` (overlaps disallowed in v1).
+- On click → `offsetsFromSelection` → `createHighlight` → optimistic paint → clear
+  selection.
+- Decorate all blocks on mount and whenever the highlight set changes.
+- On clicking an existing `<mark>` → **note popover** anchored to it: a textarea with
+  Save and Delete.
+
+The reader route (`app/reader/[id]/page.tsx`) already redirects unauthenticated users
+to `/login`, so the viewer is always signed in — there is no anonymous reader path to
+handle. `loadHighlights` still guards on `currentUser()` (returns `[]` when logged out)
+as defensive practice, mirroring `loadProgress`.
+
+`app/reader/[id]/page.tsx` (via `components/ReaderView.tsx`) loads `initialHighlights`
+server-side — exactly like `initialProgress` — and passes them to `HtmlReader`, which
+forwards them to `HighlightLayer`.
+
+### Styling — `app/globals.css`
+
+`.pd-highlight`: translucent amber via a new `--highlight-bg` token (dark-mode aware),
+inheriting text color; a `has-note` variant gets a subtle underline/dot indicator.
+Single color in v1.
+
+## Error & edge-case handling
+
+- **Drift** (sanitized HTML regenerated): `quote` no longer matches the live slice →
+  `decorateBlock` skips that highlight. Data is preserved; it simply doesn't render.
+  (Quote-based re-anchoring recovery is out of scope.)
+- **Selection spanning blocks:** clamp to the starting block (`offsetsFromSelection`
+  uses the start container's `[data-blk]` and clamps `end` to that block's length).
+- **Overlaps:** prevented at creation (toolbar suppressed when the selection intersects
+  an existing mark).
+- **Collapsed / whitespace-only / inside-`<math>` selections:** ignored.
+- **Length caps:** note (e.g. 2000 chars) and quote enforced via zod and at the DB
+  layer where practical.
+
+## Testing strategy (TDD)
+
+- **Pure functions (no DOM):** `absoluteOffset`, `rangesToWrap` — single-node,
+  multi-node, boundary, and out-of-range cases.
+- **jsdom:** `offsetsFromSelection` (across inline `<em>`, cross-block clamp, `null` on
+  collapsed/in-`<math>`), `decorateBlock` (wrap correctness, quote-mismatch skip,
+  math skip, idempotent re-decorate).
+- **Server actions:** auth guard + zod validation, with Supabase mocked to match the
+  existing test patterns in the repo.
+- **Component:** `HighlightLayer` — selection → toolbar → create; click mark → popover
+  → save/delete — via `@testing-library/react`.
+
+## File map
+
+| File | Change |
+|---|---|
+| `supabase/migrations/0006_highlights.sql` | new — table + RLS |
+| `lib/types.ts` | + `Highlight` type |
+| `lib/reader/highlightRange.ts` | new — pure offset math + DOM adapters |
+| `lib/db/highlightRow.ts` | new — row⇄`Highlight` mappers + zod |
+| `app/actions/highlights.ts` | new — load/create/updateNote/delete server actions |
+| `components/HighlightLayer.tsx` | new — selection toolbar, decoration, note popover |
+| `components/HtmlReader.tsx` | wire in `HighlightLayer` (reuses existing `containerRef`) |
+| `app/reader/[id]/page.tsx`, `components/ReaderView.tsx` | load + pass `initialHighlights` |
+| `app/globals.css` | `.pd-highlight` styles + `--highlight-bg` token |
+| tests alongside the above | per the testing strategy |
+
+## Out of scope (future branches)
+
+PDF reader highlights; cross-block ranges; multi-color; global "My Notes" page; count
+badges on paper cards; export (BibTeX/markdown); recovery/re-anchoring of drifted
+highlights.

--- a/lib/db/highlightRow.ts
+++ b/lib/db/highlightRow.ts
@@ -1,0 +1,59 @@
+import { z } from "zod";
+import type { Highlight } from "@/lib/types";
+
+export const NOTE_MAX = 2000;
+export const QUOTE_MAX = 1000;
+
+/** A row of the `highlights` table as read back from Postgres. */
+export interface HighlightRow {
+  id: string;
+  paper_id: string;
+  block_anchor: string;
+  start_offset: number;
+  end_offset: number;
+  quote: string;
+  note: string | null;
+}
+
+/** The validated payload a client sends to create a highlight. */
+export const highlightInputSchema = z
+  .object({
+    paperId: z.string().min(1),
+    blockAnchor: z.string().min(1),
+    startOffset: z.number().int().nonnegative(),
+    endOffset: z.number().int().nonnegative(),
+    quote: z.string().min(1).max(QUOTE_MAX),
+    note: z.string().max(NOTE_MAX).nullable().optional(),
+  })
+  .refine((v) => v.endOffset > v.startOffset, {
+    message: "endOffset must be greater than startOffset",
+    path: ["endOffset"],
+  });
+
+export type HighlightInput = z.infer<typeof highlightInputSchema>;
+
+/** Map a DB row to the app-facing Highlight shape. */
+export function rowToHighlight(row: HighlightRow): Highlight {
+  return {
+    id: row.id,
+    paperId: row.paper_id,
+    blockAnchor: row.block_anchor,
+    startOffset: row.start_offset,
+    endOffset: row.end_offset,
+    quote: row.quote,
+    note: row.note,
+  };
+}
+
+/** Build the insert payload for a new highlight row. */
+export function highlightInsert(userId: string, input: HighlightInput) {
+  return {
+    user_id: userId,
+    paper_id: input.paperId,
+    block_anchor: input.blockAnchor,
+    start_offset: input.startOffset,
+    end_offset: input.endOffset,
+    quote: input.quote,
+    note: input.note ?? null,
+  };
+}

--- a/lib/reader/highlightRange.ts
+++ b/lib/reader/highlightRange.ts
@@ -1,0 +1,44 @@
+/**
+ * Highlight anchoring for the HTML reader. Offsets are character indices into a
+ * block's normalized textContent (the in-order concatenation of its descendant
+ * text nodes). The same text-node walk is used at creation and at render time,
+ * so offsets stay consistent across inline markup (<em>, <a>, <code>).
+ */
+
+/** Sum of text-node lengths before nodeIndex, plus the in-node offset. */
+export function absoluteOffset(
+  nodeLengths: number[],
+  nodeIndex: number,
+  offsetInNode: number,
+): number {
+  let total = 0;
+  for (let i = 0; i < nodeIndex; i++) total += nodeLengths[i] ?? 0;
+  return total + offsetInNode;
+}
+
+export interface WrapSpan {
+  nodeIndex: number;
+  from: number;
+  to: number;
+}
+
+/**
+ * Given a block's text-node lengths (document order) and an absolute [start, end)
+ * range over their concatenation, return the per-node sub-spans the range covers.
+ * Nodes fully outside the range are omitted; the offsets in each span are local
+ * to that node.
+ */
+export function rangesToWrap(nodeLengths: number[], start: number, end: number): WrapSpan[] {
+  const spans: WrapSpan[] = [];
+  let pos = 0;
+  for (let i = 0; i < nodeLengths.length; i++) {
+    const len = nodeLengths[i] ?? 0;
+    const nodeStart = pos;
+    const nodeEnd = pos + len;
+    const from = Math.max(start, nodeStart);
+    const to = Math.min(end, nodeEnd);
+    if (to > from) spans.push({ nodeIndex: i, from: from - nodeStart, to: to - nodeStart });
+    pos = nodeEnd;
+  }
+  return spans;
+}

--- a/lib/reader/highlightRange.ts
+++ b/lib/reader/highlightRange.ts
@@ -42,3 +42,125 @@ export function rangesToWrap(nodeLengths: number[], start: number, end: number):
   }
   return spans;
 }
+
+export const MARK_CLASS = "pd-highlight";
+
+/** Ordered descendant text nodes of a block (includes those inside <math>). */
+export function textNodesOf(block: Element): Text[] {
+  const walker = document.createTreeWalker(block, NodeFilter.SHOW_TEXT);
+  const nodes: Text[] = [];
+  for (let n = walker.nextNode(); n; n = walker.nextNode()) nodes.push(n as Text);
+  return nodes;
+}
+
+function isInsideMath(node: Node): boolean {
+  let el: Element | null = node.parentElement;
+  while (el) {
+    if (el.tagName.toLowerCase() === "math") return true;
+    el = el.parentElement;
+  }
+  return false;
+}
+
+/**
+ * Compute {start, end, quote} for a selection Range, as offsets into the block's
+ * textContent, clamped to the block. Returns null when the selection is collapsed,
+ * starts outside the block, has non-text endpoints, or its endpoints are inside a
+ * <math> subtree.
+ */
+export function offsetsFromSelection(
+  block: Element,
+  range: Range,
+): { start: number; end: number; quote: string } | null {
+  if (range.collapsed) return null;
+  const nodes = textNodesOf(block);
+  if (nodes.length === 0) return null;
+  const lengths = nodes.map((t) => t.data.length);
+
+  const startIdx = nodes.indexOf(range.startContainer as Text);
+  if (startIdx === -1 || isInsideMath(nodes[startIdx])) return null;
+  const start = absoluteOffset(lengths, startIdx, range.startOffset);
+
+  const total = lengths.reduce((a, b) => a + b, 0);
+  const endIdx = nodes.indexOf(range.endContainer as Text);
+  let end: number;
+  if (endIdx === -1) {
+    end = total; // selection runs past this block — clamp to its end
+  } else {
+    if (isInsideMath(nodes[endIdx])) return null;
+    end = absoluteOffset(lengths, endIdx, range.endOffset);
+  }
+  if (end <= start) return null;
+
+  const quote = nodes
+    .map((t) => t.data)
+    .join("")
+    .slice(start, end);
+  if (!quote) return null;
+  return { start, end, quote };
+}
+
+export interface DecorateTarget {
+  id: string;
+  startOffset: number;
+  endOffset: number;
+  quote: string;
+  hasNote: boolean;
+}
+
+/**
+ * Paint each highlight as a <mark> inside the block. Recomputes text nodes per
+ * highlight (so already-painted marks are accounted for), skips a highlight whose
+ * quote no longer matches the live slice (drift), and skips sub-spans inside <math>.
+ */
+export function decorateBlock(
+  block: Element,
+  highlights: DecorateTarget[],
+  onClick: (id: string) => void,
+): void {
+  for (const h of highlights) {
+    const nodes = textNodesOf(block);
+    const lengths = nodes.map((t) => t.data.length);
+    const text = nodes.map((t) => t.data).join("");
+    if (text.slice(h.startOffset, h.endOffset) !== h.quote) continue; // drift — skip
+
+    // Resolve to concrete node references BEFORE mutating; each is wrapped once,
+    // so wrapping one (which splits only that text node) never invalidates another.
+    const targets = rangesToWrap(lengths, h.startOffset, h.endOffset)
+      .map((s) => ({ node: nodes[s.nodeIndex], from: s.from, to: s.to }))
+      .filter((t) => t.node && !isInsideMath(t.node));
+    for (const t of targets) wrapTextRange(t.node, t.from, t.to, h, onClick);
+  }
+}
+
+function wrapTextRange(
+  node: Text,
+  from: number,
+  to: number,
+  h: DecorateTarget,
+  onClick: (id: string) => void,
+): void {
+  const range = document.createRange();
+  range.setStart(node, from);
+  range.setEnd(node, to);
+  const mark = document.createElement("mark");
+  mark.className = MARK_CLASS;
+  mark.dataset.hlId = h.id;
+  if (h.hasNote) mark.dataset.hlNote = "1";
+  mark.addEventListener("click", (e) => {
+    e.stopPropagation();
+    onClick(h.id);
+  });
+  range.surroundContents(mark);
+}
+
+/** Unwrap every highlight mark under root, restoring plain text. */
+export function clearHighlights(root: Element): void {
+  root.querySelectorAll(`mark.${MARK_CLASS}`).forEach((mark) => {
+    const parent = mark.parentNode;
+    if (!parent) return;
+    while (mark.firstChild) parent.insertBefore(mark.firstChild, mark);
+    parent.removeChild(mark);
+    parent.normalize(); // merge the split text nodes back together
+  });
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -64,3 +64,17 @@ export interface ProgressRow {
   readerKind: "html" | "pdf" | null;
   status: ReadingStatus;
 }
+
+/** A user's text highlight (+ optional note) within a paper's HTML reader. */
+export interface Highlight {
+  id: string;
+  paperId: string;
+  blockAnchor: string;
+  /** Char offset into the block's textContent (inclusive). */
+  startOffset: number;
+  /** Char offset into the block's textContent (exclusive). */
+  endOffset: number;
+  /** The selected text — used to display the note and to detect anchor drift. */
+  quote: string;
+  note: string | null;
+}

--- a/supabase/migrations/0006_highlights.sql
+++ b/supabase/migrations/0006_highlights.sql
@@ -1,0 +1,23 @@
+-- Per-user text highlights + optional notes for the HTML reader.
+-- Anchored to a block's data-blk index plus char offsets into its textContent.
+create table if not exists highlights (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  paper_id uuid not null references papers(id) on delete cascade,
+  block_anchor text not null,      -- the data-blk value, e.g. "12"
+  start_offset int not null,       -- char index into the block's textContent
+  end_offset int not null,         -- exclusive
+  quote text not null,             -- selected text: drift detection + popover display
+  note text,                       -- optional comment (nullable)
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  check (start_offset >= 0 and end_offset > start_offset)
+);
+create index if not exists highlights_user_paper_idx
+  on highlights (user_id, paper_id, created_at);
+
+alter table highlights enable row level security;
+
+drop policy if exists "highlights owner" on highlights;
+create policy "highlights owner" on highlights
+  for all using (auth.uid() = user_id) with check (auth.uid() = user_id);

--- a/tests/actions/highlights.test.ts
+++ b/tests/actions/highlights.test.ts
@@ -1,0 +1,141 @@
+import { test, expect, vi, beforeEach } from "vitest";
+import type { User } from "@supabase/supabase-js";
+
+const mocks = vi.hoisted(() => {
+  // select(...).eq(...).eq(...).order(...) -> { data, error }
+  const order = vi.fn(async () => ({ data: [] as unknown[], error: null }));
+  const selectEq2 = vi.fn(() => ({ order }));
+  const selectEq1 = vi.fn(() => ({ eq: selectEq2 }));
+  const select = vi.fn(() => ({ eq: selectEq1 }));
+  // insert(...).select(...).single() -> { data, error }
+  const single = vi.fn(async () => ({ data: null as unknown, error: null as unknown }));
+  const insertSelect = vi.fn(() => ({ single }));
+  const insert = vi.fn(() => ({ select: insertSelect }));
+  // update(...).eq(...).eq(...) -> { error }
+  const updateEq2 = vi.fn(async () => ({ error: null }));
+  const updateEq1 = vi.fn(() => ({ eq: updateEq2 }));
+  const update = vi.fn(() => ({ eq: updateEq1 }));
+  // delete().eq(...).eq(...) -> { error }
+  const deleteEq2 = vi.fn(async () => ({ error: null }));
+  const deleteEq1 = vi.fn(() => ({ eq: deleteEq2 }));
+  const del = vi.fn(() => ({ eq: deleteEq1 }));
+
+  const from = vi.fn(() => ({ select, insert, update, delete: del }));
+  return {
+    order,
+    single,
+    insert,
+    insertSelect,
+    update,
+    updateEq2,
+    del,
+    deleteEq2,
+    from,
+    currentUser: vi.fn(async (): Promise<User | null> => null),
+  };
+});
+
+vi.mock("@/lib/auth", () => ({ currentUser: mocks.currentUser }));
+vi.mock("@/lib/db/server", () => ({ serverClient: async () => ({ from: mocks.from }) }));
+
+import { loadHighlights, createHighlight, deleteHighlight } from "@/app/actions/highlights";
+
+const USER = { id: "user-1" } as User;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.currentUser.mockResolvedValue(USER);
+});
+
+test("loadHighlights returns [] and skips the DB when signed out", async () => {
+  mocks.currentUser.mockResolvedValue(null);
+  expect(await loadHighlights("p1")).toEqual([]);
+  expect(mocks.from).not.toHaveBeenCalled();
+});
+
+test("loadHighlights maps returned rows to the app shape", async () => {
+  mocks.order.mockResolvedValue({
+    data: [
+      {
+        id: "h1",
+        paper_id: "p1",
+        block_anchor: "2",
+        start_offset: 0,
+        end_offset: 4,
+        quote: "test",
+        note: null,
+      },
+    ],
+    error: null,
+  });
+  const result = await loadHighlights("p1");
+  expect(result).toEqual([
+    {
+      id: "h1",
+      paperId: "p1",
+      blockAnchor: "2",
+      startOffset: 0,
+      endOffset: 4,
+      quote: "test",
+      note: null,
+    },
+  ]);
+});
+
+test("createHighlight returns null and skips insert on invalid input", async () => {
+  const result = await createHighlight({
+    paperId: "p1",
+    blockAnchor: "2",
+    startOffset: 5,
+    endOffset: 5, // end <= start
+    quote: "x",
+  });
+  expect(result).toBeNull();
+  expect(mocks.insert).not.toHaveBeenCalled();
+});
+
+test("createHighlight inserts and returns the mapped row on success", async () => {
+  mocks.single.mockResolvedValue({
+    data: {
+      id: "h9",
+      paper_id: "p1",
+      block_anchor: "2",
+      start_offset: 0,
+      end_offset: 4,
+      quote: "test",
+      note: null,
+    },
+    error: null,
+  });
+  const result = await createHighlight({
+    paperId: "p1",
+    blockAnchor: "2",
+    startOffset: 0,
+    endOffset: 4,
+    quote: "test",
+  });
+  expect(result).toEqual({
+    id: "h9",
+    paperId: "p1",
+    blockAnchor: "2",
+    startOffset: 0,
+    endOffset: 4,
+    quote: "test",
+    note: null,
+  });
+  expect(mocks.insert).toHaveBeenCalledWith({
+    user_id: "user-1",
+    paper_id: "p1",
+    block_anchor: "2",
+    start_offset: 0,
+    end_offset: 4,
+    quote: "test",
+    note: null,
+  });
+});
+
+test("deleteHighlight is a no-op when signed out", async () => {
+  mocks.currentUser.mockResolvedValue(null);
+  await deleteHighlight("h1");
+  expect(mocks.from).not.toHaveBeenCalled();
+});

--- a/tests/components/HighlightLayer.test.tsx
+++ b/tests/components/HighlightLayer.test.tsx
@@ -1,0 +1,148 @@
+import { test, expect, vi, beforeEach } from "vitest";
+import { useRef } from "react";
+import { render, screen, fireEvent, act } from "@testing-library/react";
+
+const actions = vi.hoisted(() => ({
+  createHighlight: vi.fn(),
+  updateHighlightNote: vi.fn(async () => {}),
+  deleteHighlight: vi.fn(async () => {}),
+}));
+vi.mock("@/app/actions/highlights", () => actions);
+
+import { HighlightLayer } from "@/components/HighlightLayer";
+import type { Highlight } from "@/lib/types";
+
+const HTML = `<p data-blk="0">Diffusion models are great</p>`;
+
+function Harness({ initial }: { initial: Highlight[] }) {
+  const ref = useRef<HTMLDivElement>(null);
+  return (
+    <div>
+      <div ref={ref} dangerouslySetInnerHTML={{ __html: HTML }} />
+      <HighlightLayer paperId="p1" containerRef={ref} initialHighlights={initial} />
+    </div>
+  );
+}
+
+function selectText(container: HTMLElement, from: number, to: number) {
+  const p = container.querySelector('[data-blk="0"]')!;
+  const textNode = p.firstChild!;
+  const range = document.createRange();
+  range.setStart(textNode, from);
+  range.setEnd(textNode, to);
+  const sel = window.getSelection()!;
+  sel.removeAllRanges();
+  sel.addRange(range);
+  fireEvent.mouseUp(document);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+test("an initial highlight is painted as a mark on mount", () => {
+  const { container } = render(
+    <Harness
+      initial={[
+        {
+          id: "h1",
+          paperId: "p1",
+          blockAnchor: "0",
+          startOffset: 10,
+          endOffset: 16,
+          quote: "models",
+          note: "hi",
+        },
+      ]}
+    />,
+  );
+  const mark = container.querySelector("mark.pd-highlight");
+  expect(mark).not.toBeNull();
+  expect(mark!.textContent).toBe("models");
+});
+
+test("selecting text shows the Highlight button; clicking it creates and paints a highlight", async () => {
+  actions.createHighlight.mockResolvedValue({
+    id: "h2",
+    paperId: "p1",
+    blockAnchor: "0",
+    startOffset: 10,
+    endOffset: 16,
+    quote: "models",
+    note: null,
+  });
+  const { container } = render(<Harness initial={[]} />);
+
+  selectText(container, 10, 16); // "models"
+  const btn = await screen.findByRole("button", { name: /highlight/i });
+
+  await act(async () => {
+    fireEvent.click(btn);
+  });
+
+  expect(actions.createHighlight).toHaveBeenCalledWith({
+    paperId: "p1",
+    blockAnchor: "0",
+    startOffset: 10,
+    endOffset: 16,
+    quote: "models",
+    note: null,
+  });
+  expect(container.querySelector('mark.pd-highlight[data-hl-id="h2"]')).not.toBeNull();
+});
+
+test("clicking an existing mark opens the note editor; saving calls updateHighlightNote", async () => {
+  const { container } = render(
+    <Harness
+      initial={[
+        {
+          id: "h1",
+          paperId: "p1",
+          blockAnchor: "0",
+          startOffset: 10,
+          endOffset: 16,
+          quote: "models",
+          note: null,
+        },
+      ]}
+    />,
+  );
+  const mark = container.querySelector("mark.pd-highlight")!;
+
+  await act(async () => {
+    fireEvent.click(mark);
+  });
+  const textarea = await screen.findByRole("textbox");
+  fireEvent.change(textarea, { target: { value: "key idea" } });
+
+  await act(async () => {
+    fireEvent.click(screen.getByRole("button", { name: /save/i }));
+  });
+  expect(actions.updateHighlightNote).toHaveBeenCalledWith("h1", "key idea");
+});
+
+test("deleting from the editor calls deleteHighlight and removes the mark", async () => {
+  const { container } = render(
+    <Harness
+      initial={[
+        {
+          id: "h1",
+          paperId: "p1",
+          blockAnchor: "0",
+          startOffset: 10,
+          endOffset: 16,
+          quote: "models",
+          note: null,
+        },
+      ]}
+    />,
+  );
+  await act(async () => {
+    fireEvent.click(container.querySelector("mark.pd-highlight")!);
+  });
+  await act(async () => {
+    fireEvent.click(screen.getByRole("button", { name: /delete/i }));
+  });
+  expect(actions.deleteHighlight).toHaveBeenCalledWith("h1");
+  expect(container.querySelector("mark.pd-highlight")).toBeNull();
+});

--- a/tests/components/HtmlReader.test.tsx
+++ b/tests/components/HtmlReader.test.tsx
@@ -7,6 +7,13 @@ const { saveProgress } = vi.hoisted(() => ({
 }));
 vi.mock("@/app/actions/progress", () => ({ saveProgress }));
 
+vi.mock("@/app/actions/highlights", () => ({
+  loadHighlights: vi.fn(async () => []),
+  createHighlight: vi.fn(),
+  updateHighlightNote: vi.fn(async () => {}),
+  deleteHighlight: vi.fn(async () => {}),
+}));
+
 import { HtmlReader } from "@/components/HtmlReader";
 import type { ProgressRow } from "@/lib/types";
 
@@ -35,6 +42,28 @@ test("renders the paper HTML content", () => {
   renderReader(null);
   expect(screen.getByText("Alpha")).toBeInTheDocument();
   expect(screen.getByText("Gamma")).toBeInTheDocument();
+});
+
+test("paints an initial highlight passed to the reader", () => {
+  const { container } = render(
+    <HtmlReader
+      paperId="p1"
+      html={HTML}
+      initialProgress={null}
+      initialHighlights={[
+        {
+          id: "h1",
+          paperId: "p1",
+          blockAnchor: "1",
+          startOffset: 0,
+          endOffset: 4,
+          quote: "Beta",
+          note: null,
+        },
+      ]}
+    />,
+  );
+  expect(container.querySelector('mark.pd-highlight[data-hl-id="h1"]')?.textContent).toBe("Beta");
 });
 
 test("does not render manual mark controls — progress is automatic", () => {

--- a/tests/db/highlightRow.test.ts
+++ b/tests/db/highlightRow.test.ts
@@ -1,0 +1,83 @@
+import { test, expect } from "vitest";
+import {
+  rowToHighlight,
+  highlightInsert,
+  highlightInputSchema,
+  type HighlightRow,
+} from "@/lib/db/highlightRow";
+
+const ROW: HighlightRow = {
+  id: "h1",
+  paper_id: "p1",
+  block_anchor: "12",
+  start_offset: 3,
+  end_offset: 9,
+  quote: "sample",
+  note: "a note",
+};
+
+test("rowToHighlight maps snake_case columns to the camelCase app shape", () => {
+  expect(rowToHighlight(ROW)).toEqual({
+    id: "h1",
+    paperId: "p1",
+    blockAnchor: "12",
+    startOffset: 3,
+    endOffset: 9,
+    quote: "sample",
+    note: "a note",
+  });
+});
+
+test("highlightInsert builds the row payload with the user id and null note default", () => {
+  expect(
+    highlightInsert("user-1", {
+      paperId: "p1",
+      blockAnchor: "12",
+      startOffset: 3,
+      endOffset: 9,
+      quote: "sample",
+    }),
+  ).toEqual({
+    user_id: "user-1",
+    paper_id: "p1",
+    block_anchor: "12",
+    start_offset: 3,
+    end_offset: 9,
+    quote: "sample",
+    note: null,
+  });
+});
+
+test("schema rejects an empty selection (end <= start)", () => {
+  const r = highlightInputSchema.safeParse({
+    paperId: "p1",
+    blockAnchor: "12",
+    startOffset: 5,
+    endOffset: 5,
+    quote: "x",
+  });
+  expect(r.success).toBe(false);
+});
+
+test("schema rejects a quote that is too long", () => {
+  const r = highlightInputSchema.safeParse({
+    paperId: "p1",
+    blockAnchor: "12",
+    startOffset: 0,
+    endOffset: 1,
+    quote: "x".repeat(1001),
+  });
+  expect(r.success).toBe(false);
+});
+
+test("schema accepts a valid input with an optional note", () => {
+  const r = highlightInputSchema.safeParse({
+    paperId: "p1",
+    blockAnchor: "12",
+    startOffset: 0,
+    endOffset: 4,
+    quote: "test",
+    note: "hi",
+  });
+  expect(r.success).toBe(true);
+});

--- a/tests/reader/highlightRange.test.ts
+++ b/tests/reader/highlightRange.test.ts
@@ -1,0 +1,25 @@
+import { test, expect } from "vitest";
+import { absoluteOffset, rangesToWrap } from "@/lib/reader/highlightRange";
+
+test("absoluteOffset sums prior node lengths plus the in-node offset", () => {
+  expect(absoluteOffset([5, 3, 8], 0, 2)).toBe(2);
+  expect(absoluteOffset([5, 3, 8], 1, 1)).toBe(6); // 5 + 1
+  expect(absoluteOffset([5, 3, 8], 2, 4)).toBe(12); // 5 + 3 + 4
+});
+
+test("rangesToWrap covers a single node", () => {
+  expect(rangesToWrap([10], 2, 6)).toEqual([{ nodeIndex: 0, from: 2, to: 6 }]);
+});
+
+test("rangesToWrap splits a range across multiple nodes", () => {
+  // nodes: [0..5) [5..8) [8..16); range [3, 12)
+  expect(rangesToWrap([5, 3, 8], 3, 12)).toEqual([
+    { nodeIndex: 0, from: 3, to: 5 },
+    { nodeIndex: 1, from: 0, to: 3 },
+    { nodeIndex: 2, from: 0, to: 4 },
+  ]);
+});
+
+test("rangesToWrap omits nodes fully outside the range", () => {
+  expect(rangesToWrap([4, 4, 4], 5, 7)).toEqual([{ nodeIndex: 1, from: 1, to: 3 }]);
+});

--- a/tests/reader/highlightRange.test.ts
+++ b/tests/reader/highlightRange.test.ts
@@ -1,5 +1,13 @@
 import { test, expect } from "vitest";
-import { absoluteOffset, rangesToWrap } from "@/lib/reader/highlightRange";
+import {
+  absoluteOffset,
+  rangesToWrap,
+  offsetsFromSelection,
+  decorateBlock,
+  clearHighlights,
+  MARK_CLASS,
+  type DecorateTarget,
+} from "@/lib/reader/highlightRange";
 
 test("absoluteOffset sums prior node lengths plus the in-node offset", () => {
   expect(absoluteOffset([5, 3, 8], 0, 2)).toBe(2);
@@ -22,4 +30,74 @@ test("rangesToWrap splits a range across multiple nodes", () => {
 
 test("rangesToWrap omits nodes fully outside the range", () => {
   expect(rangesToWrap([4, 4, 4], 5, 7)).toEqual([{ nodeIndex: 1, from: 1, to: 3 }]);
+});
+
+function block(html: string): HTMLElement {
+  const el = document.createElement("div");
+  el.setAttribute("data-blk", "0");
+  el.innerHTML = html;
+  document.body.appendChild(el);
+  return el;
+}
+
+function selectRange(node: Node, start: number, end: number): Range {
+  const range = document.createRange();
+  range.setStart(node, start);
+  range.setEnd(node, end);
+  return range;
+}
+
+test("offsetsFromSelection returns offsets + quote across inline markup", () => {
+  // textContent = "Diffusion models are great"  (em wraps "models")
+  const el = block("Diffusion <em>models</em> are great");
+  const emText = el.querySelector("em")!.firstChild!; // "models"
+  const r = selectRange(emText, 0, 6); // "models"
+  expect(offsetsFromSelection(el, r)).toEqual({ start: 10, end: 16, quote: "models" });
+});
+
+test("offsetsFromSelection returns null for a collapsed selection", () => {
+  const el = block("hello world");
+  const r = selectRange(el.firstChild!, 3, 3);
+  expect(offsetsFromSelection(el, r)).toBeNull();
+});
+
+test("offsetsFromSelection clamps an end that runs past the block", () => {
+  const el = block("abcdef");
+  const r = document.createRange();
+  r.setStart(el.firstChild!, 2);
+  r.setEndAfter(el); // end outside the block's text nodes
+  const res = offsetsFromSelection(el, r);
+  expect(res).toEqual({ start: 2, end: 6, quote: "cdef" });
+});
+
+test("decorateBlock wraps the range in a mark and skips drifted quotes", () => {
+  const el = block("Diffusion models are great");
+  const targets: DecorateTarget[] = [
+    { id: "h1", startOffset: 10, endOffset: 16, quote: "models", hasNote: true },
+    { id: "h2", startOffset: 0, endOffset: 9, quote: "STALE!!!", hasNote: false }, // drift → skip
+  ];
+  const clicked: string[] = [];
+  decorateBlock(el, targets, (id) => clicked.push(id));
+
+  const marks = el.querySelectorAll(`mark.${MARK_CLASS}`);
+  expect(marks.length).toBe(1);
+  expect(marks[0].textContent).toBe("models");
+  expect((marks[0] as HTMLElement).dataset.hlId).toBe("h1");
+  expect((marks[0] as HTMLElement).dataset.hlNote).toBe("1");
+
+  (marks[0] as HTMLElement).click();
+  expect(clicked).toEqual(["h1"]);
+});
+
+test("clearHighlights removes marks and restores plain text", () => {
+  const el = block("Diffusion models are great");
+  decorateBlock(
+    el,
+    [{ id: "h1", startOffset: 10, endOffset: 16, quote: "models", hasNote: false }],
+    () => {},
+  );
+  expect(el.querySelectorAll(`mark.${MARK_CLASS}`).length).toBe(1);
+  clearHighlights(el);
+  expect(el.querySelectorAll(`mark.${MARK_CLASS}`).length).toBe(0);
+  expect(el.textContent).toBe("Diffusion models are great");
 });


### PR DESCRIPTION
## Summary

Adds **text-selection highlights with optional notes** to the HTML reader (v1). Select a phrase → click **Highlight** → it persists across reloads and devices; click a highlight to add/edit/delete a note. Notes get a subtle underline cue.

Design spec: `docs/superpowers/specs/2026-06-23-highlights-notes-design.md`
Plan: `docs/superpowers/plans/2026-06-23-highlights-notes.md`

## How it works

- Highlights anchor to the reader's existing `data-blk` block index + character offsets into that block's normalized `textContent`, so creation and render use the same text-node walk (robust across inline `<em>`/`<a>`/`<code>`).
- Painted **client-side** as `<mark>` elements after the cached HTML mounts, so per-user data never enters the shared `paper_content` cache.
- Pure offset math (`absoluteOffset`, `rangesToWrap`) is isolated and unit-tested; `HighlightLayer` owns the selection toolbar, decoration, and note popover.
- Drift-safe: a highlight whose stored `quote` no longer matches the live slice is skipped, not mis-painted.

## Scope (v1)

HTML reader only · text selection clamped to a single block · optional note per highlight · in-reader surfacing · single color · overlaps disallowed at creation.

**Out of scope (later):** PDF highlights, cross-block ranges, multi-color, a global "My Notes" page, card badges, export, drift recovery.

## Data

New `highlights` table (RLS: owner-only), migration `supabase/migrations/0006_highlights.sql` — already applied to the project.

## Testing

- New unit/jsdom/component tests for offset math, DOM adapters, server actions, and `HighlightLayer`.
- Full suite: **134 passed**; `typecheck`, `lint` (0 errors), and `pnpm build` all green.

## Manual smoke (recommended before merge)

Sign in, open an HTML paper, select a sentence → Highlight → reload (persists) → click → add note → Save → reload (underline cue) → click → Delete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)