### PR TITLE
ci: Claude PR reviewer with verdict-gated auto-approve

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,10 @@
+# Code owners. Your "production" ruleset has require_code_owner_review = true, so
+# a PR's approval must come from a code owner listed here. The automated reviewer
+# machine account owns everything, so its Claude-gated approval satisfies the rule.
+#
+# ⚠️ REPLACE the placeholder below with your real bot account's @username BEFORE
+# merging this. An unknown/invalid username here is silently ignored by GitHub,
+# which — with require_code_owner_review on — would leave every PR permanently
+# unmergeable. See docs/claude-pr-reviewer.md.
+
+* @REPLACE-WITH-REVIEW-BOT-USERNAME

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,9 +2,9 @@
 # a PR's approval must come from a code owner listed here. The automated reviewer
 # machine account owns everything, so its Claude-gated approval satisfies the rule.
 #
-# ⚠️ REPLACE the placeholder below with your real bot account's @username BEFORE
-# merging this. An unknown/invalid username here is silently ignored by GitHub,
-# which — with require_code_owner_review on — would leave every PR permanently
-# unmergeable. See docs/claude-pr-reviewer.md.
+# ⚠️ The owner below MUST be a real user with Write access to this repo. An
+# unknown/invalid username is silently ignored by GitHub, which — with
+# require_code_owner_review on — would leave every PR permanently unmergeable.
+# Keep this in sync with the review bot. See docs/claude-pr-reviewer.md.
 
-* @REPLACE-WITH-REVIEW-BOT-USERNAME
+* @CaffeinatedSimon

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -13,6 +13,7 @@ permissions:
   contents: read
   pull-requests: write
   issues: write
+  id-token: write # claude-code-action authenticates to GitHub via OIDC
 
 # One review per PR at a time; a new push cancels an in-flight review.
 concurrency:

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,94 @@
+name: Claude PR review
+
+# Reviews every PR with Claude and, gated on Claude's own verdict, submits an
+# approving OR request-changes review as a dedicated machine user (the default
+# GITHUB_TOKEN cannot approve PRs, so the approval step needs REVIEW_BOT_TOKEN).
+# See docs/claude-pr-reviewer.md for the one-time account/secret/CODEOWNERS setup.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+# One review per PR at a time; a new push cancels an in-flight review.
+concurrency:
+  group: claude-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    # Only same-repo PRs (skip forks — they don't receive secrets anyway).
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Claude review
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_args: "--max-turns 20 --model claude-sonnet-5"
+          prompt: |
+            Review pull request #${{ github.event.pull_request.number }} in ${{ github.repository }}.
+
+            Steps:
+            1. Read AGENTS.md / CLAUDE.md for this project's conventions.
+            2. Diff the PR against its base:
+               `git diff origin/${{ github.event.pull_request.base.ref }}...HEAD`
+            3. Review the changed code for: correctness bugs, security issues,
+               performance regressions, and violations of the project conventions.
+               Ignore pre-existing issues outside the diff.
+            4. Post ONE concise review comment on the PR summarizing what you found,
+               grouped by severity (Blocking / Non-blocking / Nits). If nothing is
+               wrong, say so briefly.
+            5. Decide a verdict:
+               - "approve"  ONLY if there are NO blocking issues (no bugs, no security
+                 holes, nothing that would break the build or tests).
+               - "request_changes" otherwise.
+               Be strict: when uncertain, choose "request_changes".
+            6. MANDATORY: write the verdict to `claude-verdict.json` in the repo root,
+               exactly this shape and nothing else:
+               {"verdict":"approve","summary":"one-line reason"}
+               or
+               {"verdict":"request_changes","summary":"one-line reason"}
+
+      - name: Read verdict (fail safe to request_changes)
+        id: verdict
+        run: |
+          if [ ! -f claude-verdict.json ]; then
+            echo "verdict=request_changes" >> "$GITHUB_OUTPUT"
+            echo "summary=No verdict file produced — failing safe." >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          v=$(jq -r 'if .verdict == "approve" then "approve" else "request_changes" end' claude-verdict.json)
+          # Collapse newlines and clamp so the summary is safe to carry as an output.
+          s=$(jq -r '(.summary // "") | gsub("[\\n\\r\\t]"; " ") | .[0:280]' claude-verdict.json)
+          echo "verdict=$v" >> "$GITHUB_OUTPUT"
+          echo "summary=$s" >> "$GITHUB_OUTPUT"
+          echo "Claude verdict: $v — $s"
+
+      - name: Approve (gated on verdict)
+        if: steps.verdict.outputs.verdict == 'approve'
+        env:
+          GH_TOKEN: ${{ secrets.REVIEW_BOT_TOKEN }}
+          PR: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+          SUMMARY: ${{ steps.verdict.outputs.summary }}
+        run: |
+          gh pr review "$PR" --repo "$REPO" --approve --body "🤖 Claude review passed. $SUMMARY"
+
+      - name: Request changes (gated on verdict)
+        if: steps.verdict.outputs.verdict != 'approve'
+        env:
+          GH_TOKEN: ${{ secrets.REVIEW_BOT_TOKEN }}
+          PR: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+          SUMMARY: ${{ steps.verdict.outputs.summary }}
+        run: |
+          gh pr review "$PR" --repo "$REPO" --request-changes --body "🤖 Claude requested changes. $SUMMARY"

--- a/docs/claude-pr-reviewer.md
+++ b/docs/claude-pr-reviewer.md
@@ -1,0 +1,68 @@
+# Automated Claude PR reviewer (with gated auto-approve)
+
+`.github/workflows/claude-review.yml` runs Claude on every pull request, posts a
+review comment, and then — **gated on Claude's own verdict** — submits either an
+**approving** or a **request-changes** review as a dedicated machine user. That
+approval counts toward the `production` ruleset's "1 approving review + code-owner
+review" requirement, so your own PRs can merge once Claude signs off.
+
+## Why a machine user (and not the Action itself)
+
+- The official `anthropics/claude-code-action` **cannot submit approvals** — it only
+  comments. So a separate step submits the review via the GitHub CLI.
+- The default `GITHUB_TOKEN` (`github-actions[bot]`) **cannot approve PRs** either;
+  its approvals are ignored by rulesets. The step therefore uses a **machine-user
+  Personal Access Token** (`REVIEW_BOT_TOKEN`).
+- Your ruleset requires **code-owner** review, and code owners can only be **users or
+  teams — never GitHub Apps**. So the approver must be a real (machine) *user* listed
+  in `.github/CODEOWNERS`.
+
+## What the gate does
+
+Claude writes `{"verdict":"approve"|"request_changes","summary":"…"}` to
+`claude-verdict.json`. The workflow reads it and:
+
+- `approve` → bot submits an **approving** review (unblocks merge).
+- anything else, or a missing/invalid file → bot submits **request-changes**
+  (**fail-safe**: it never auto-approves on error).
+
+It re-runs on every push (`synchronize`); your ruleset has
+`dismiss_stale_reviews_on_push: true`, so each push is re-reviewed from scratch.
+
+## One-time setup
+
+1. **Create a machine account** on GitHub (e.g. `paperdeck-review-bot`) with its own
+   email. This is a permitted machine/bot account — keep it separate from your
+   personal identity.
+2. **Add it to this repo** as a collaborator with **Write** access
+   (Settings → Collaborators). Accept the invite from the bot account.
+3. **Create a token for the bot** (while signed in as the bot):
+   - Fine-grained PAT scoped to `khuynh22/paper-deck`, permissions
+     **Pull requests: Read and write** + **Contents: Read-only**. (A classic PAT with
+     `repo` scope also works.)
+4. **Add repo secrets** (Settings → Secrets and variables → Actions):
+   - `ANTHROPIC_API_KEY` — your Claude API key from <https://console.anthropic.com>.
+   - `REVIEW_BOT_TOKEN` — the bot PAT from step 3.
+5. **Edit `.github/CODEOWNERS`** — replace `@REPLACE-WITH-REVIEW-BOT-USERNAME` with the
+   bot's real `@username`. **Do this before merging** or PRs become unmergeable.
+
+## Bootstrapping (important)
+
+Installing this is itself a PR, and the `production` ruleset blocks all merges until
+an approver exists — a chicken-and-egg. Merge this **first** PR via a one-time admin
+action, then the bot handles everything afterward:
+
+- Repo → **Settings → Rules → Rulesets → production**, set enforcement to **Disabled**
+  (or add yourself to the **Bypass list**), merge this PR, then re-enable. *Or* add a
+  permanent **Repository admin** bypass so you always retain a manual override.
+
+## Cost & safety notes
+
+- Each review costs roughly a few cents to a couple dollars of Claude API usage
+  depending on diff size; `--max-turns 20` caps it. GitHub Actions minutes apply.
+- The gate trusts Claude's self-reported verdict, and the workflow/prompt live in the
+  repo — a PR that edits them could influence the outcome. Fine for a solo repo where
+  you author every PR; revisit if you add external contributors (require human review
+  for PRs that touch `.github/`).
+- `REVIEW_BOT_TOKEN` can approve merges to `master` — treat it like a deploy key:
+  store only as a secret, rotate periodically.

--- a/docs/claude-pr-reviewer.md
+++ b/docs/claude-pr-reviewer.md
@@ -36,10 +36,12 @@ It re-runs on every push (`synchronize`); your ruleset has
    personal identity.
 2. **Add it to this repo** as a collaborator with **Write** access
    (Settings → Collaborators). Accept the invite from the bot account.
-3. **Create a token for the bot** (while signed in as the bot):
-   - Fine-grained PAT scoped to `khuynh22/paper-deck`, permissions
-     **Pull requests: Read and write** + **Contents: Read-only**. (A classic PAT with
-     `repo` scope also works.)
+3. **Create a token for the bot** (while signed in as the bot). Because this repo is
+   owned by a **personal** account and the bot is only a collaborator, use a **classic
+   PAT** with the **`repo`** scope. (A *fine-grained* PAT will NOT work here — its
+   resource owner can only be the bot's own account, so it can't be scoped to
+   `khuynh22/paper-deck`. Fine-grained tokens only become an option if the repo moves
+   to an org.)
 4. **Add repo secrets** (Settings → Secrets and variables → Actions):
    - `ANTHROPIC_API_KEY` — your Claude API key from <https://console.anthropic.com>.
    - `REVIEW_BOT_TOKEN` — the bot PAT from step 3.


### PR DESCRIPTION
## What

Adds an automated Claude reviewer on every PR that, gated on Claude's own verdict, submits an **approving** or **request-changes** review as a dedicated machine user — so PRs can auto-merge once Claude signs off, while never rubber-stamping on error.

## Files

- **`.github/workflows/claude-review.yml`** — on `pull_request` (opened/synchronize/reopened): `anthropics/claude-code-action@v1` reviews + comments and writes `claude-verdict.json`; a gated step then runs `gh pr review --approve` / `--request-changes` using `REVIEW_BOT_TOKEN`. Fail-safe to request-changes on missing/invalid verdict; summary passed via env vars (no shell injection); concurrency-cancels stale runs.
- **`.github/CODEOWNERS`** — routes code-owner review to the bot (placeholder handle to replace).
- **`docs/claude-pr-reviewer.md`** — one-time setup + bootstrap runbook.

## Why a machine user

The Claude Action **cannot** submit approvals, and the default `GITHUB_TOKEN` approval is ignored by rulesets. Code owners can't be GitHub Apps — so the approver must be a real machine **user** listed in CODEOWNERS.

## Before this can merge / work (see docs)

1. Create a machine account; add as Write collaborator.
2. Secrets: `ANTHROPIC_API_KEY`, `REVIEW_BOT_TOKEN`.
3. Replace the CODEOWNERS placeholder with the bot's real `@username` (invalid handle + code-owner rule = unmergeable).
4. Bootstrap: this first PR needs a one-time admin unblock (disable ruleset or admin bypass), since all merges are currently review-gated.

⚠️ Trust model: the gate trusts Claude's self-reported verdict and the workflow lives in-repo — fine for a solo author; require human review on `.github/` changes if contributors are added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)