### PR TITLE
ci: subscription-token auth + fix reviewer permissions/turns

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -31,10 +31,16 @@ jobs:
           fetch-depth: 0
 
       - name: Claude review
+        # Never let a Claude-side error (max turns, API hiccup) abort the job —
+        # the verdict step below fails safe to request_changes so the bot still
+        # posts a review instead of leaving the PR silently un-reviewed.
+        continue-on-error: true
         uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          claude_args: "--max-turns 20 --model claude-sonnet-5"
+          # Ephemeral CI runner reviewing our own code: skip the interactive
+          # permission gate so Claude can run git/read/write the verdict file
+          # (the default mode denied those, burning all turns on denials).
+          claude_args: "--max-turns 40 --model claude-sonnet-5 --dangerously-skip-permissions"
           prompt: |
             Review pull request #${{ github.event.pull_request.number }} in ${{ github.repository }}.
 
@@ -58,6 +64,11 @@ jobs:
                {"verdict":"approve","summary":"one-line reason"}
                or
                {"verdict":"request_changes","summary":"one-line reason"}
+        env:
+          # Auth via Claude Pro/Max subscription (mint with `claude setup-token`)
+          # instead of pay-per-use API credits. The action has no OAuth *input*;
+          # Claude Code reads this env var via its auth precedence chain.
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
       - name: Read verdict (fail safe to request_changes)
         id: verdict

--- a/docs/claude-pr-reviewer.md
+++ b/docs/claude-pr-reviewer.md
@@ -42,10 +42,18 @@ It re-runs on every push (`synchronize`); your ruleset has
    resource owner can only be the bot's own account, so it can't be scoped to
    `khuynh22/paper-deck`. Fine-grained tokens only become an option if the repo moves
    to an org.)
-4. **Add repo secrets** (Settings → Secrets and variables → Actions):
-   - `ANTHROPIC_API_KEY` — your Claude API key from <https://console.anthropic.com>.
+4. **Mint a Claude subscription token** (as yourself, on a machine with Claude Code):
+   run `claude setup-token`. It opens a browser, authenticates against your **Claude
+   Pro/Max** plan, and prints a ~1-year OAuth token. This bills reviews against your
+   subscription's usage limits — **no pay-per-use API credits**. (Free plan is not
+   supported.)
+5. **Add repo secrets** (Settings → Secrets and variables → Actions):
+   - `CLAUDE_CODE_OAUTH_TOKEN` — the token from step 4. The workflow passes it to the
+     action as an **env var** (the action has no OAuth input); Claude Code reads it via
+     its auth precedence chain. To use API credits instead, delete this and set
+     `ANTHROPIC_API_KEY` + switch the step back to the `anthropic_api_key:` input.
    - `REVIEW_BOT_TOKEN` — the bot PAT from step 3.
-5. **Edit `.github/CODEOWNERS`** — replace `@REPLACE-WITH-REVIEW-BOT-USERNAME` with the
+6. **Edit `.github/CODEOWNERS`** — replace `@REPLACE-WITH-REVIEW-BOT-USERNAME` with the
    bot's real `@username`. **Do this before merging** or PRs become unmergeable.
 
 ## Bootstrapping (important)
@@ -60,8 +68,10 @@ action, then the bot handles everything afterward:
 
 ## Cost & safety notes
 
-- Each review costs roughly a few cents to a couple dollars of Claude API usage
-  depending on diff size; `--max-turns 20` caps it. GitHub Actions minutes apply.
+- Each review consumes your Claude **subscription** usage (not API credits) via the
+  OAuth token; `--max-turns 40` caps how much work one review can do. If the
+  subscription's usage limit is hit, the action gets HTTP 429 and the Claude step
+  errors — the gate then fails safe to request-changes. GitHub Actions minutes apply.
 - The gate trusts Claude's self-reported verdict, and the workflow/prompt live in the
   repo — a PR that edits them could influence the outcome. Fine for a solo repo where
   you author every PR; revisit if you add external contributors (require human review


### PR DESCRIPTION
Fixes the automated reviewer added in #20, which failed on its first real run.

## Two changes

1. **Auth → Claude subscription (no API credits).** The API key is out of credits. Switch to the Pro/Max subscription OAuth token, passed as the **env var** `CLAUDE_CODE_OAUTH_TOKEN` (the action has no OAuth input; Claude Code reads it via its auth precedence chain). Mint locally with `claude setup-token`.
2. **Fix the run failure.** The last run hit `max turns (20)` with `permission_denials_count: 12` — the default permission mode denied Claude's `git diff` / verdict-file `Write`, burning every turn on denials. Add `--dangerously-skip-permissions` (ephemeral CI runner reviewing our own code) and raise `--max-turns` to 40. Plus `continue-on-error` so a Claude-side failure still falls through to the fail-safe request-changes instead of a silently dead job.

## Requires (see docs/claude-pr-reviewer.md)
- Add repo secret **`CLAUDE_CODE_OAUTH_TOKEN`** (from `claude setup-token`, Pro/Max plan).
- Merge to `master` before it takes effect — the action's anti-tamper guard only runs a workflow that matches the default branch, so this can't be validated on its own PR (expected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)