### PR TITLE
ci: skip Claude reviewer on Dependabot PRs

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -23,8 +23,13 @@ concurrency:
 jobs:
   review:
     runs-on: ubuntu-latest
-    # Only same-repo PRs (skip forks — they don't receive secrets anyway).
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    # Skip forks (no secrets) and Dependabot PRs: GitHub runs Dependabot-triggered
+    # workflows with a read-only token and NO repo secrets, so REVIEW_BOT_TOKEN /
+    # CLAUDE_CODE_OAUTH_TOKEN resolve empty and the review/approve steps fail. Dep
+    # bumps are gated by CI (typecheck/build/test) instead.
+    if: >
+      github.actor != 'dependabot[bot]' &&
+      github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Why

The reviewer added in #20 fails on Dependabot PRs (surfaced on the TS 6 bump, #6): GitHub runs Dependabot-triggered workflows with a **read-only token and no repo secrets**, so `REVIEW_BOT_TOKEN` / `CLAUDE_CODE_OAUTH_TOKEN` are empty — the Claude step can't authenticate and the `gh pr review` steps die with `set the GH_TOKEN environment variable` (exit 4).

## Change

Guard the review job on `github.actor != 'dependabot[bot]'` (alongside the existing same-repo/fork check). Dependabot PRs now cleanly skip the reviewer instead of leaving a failing check; dependency bumps remain gated by CI (typecheck / build / test), which is the meaningful signal for a version bump.

Verified the folded `if:` parses to the intended single-line expression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)