### PR TITLE
release: v0.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "paper-deck",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "private": true,
   "packageManager": "pnpm@10.33.0",
   "scripts": {


### PR DESCRIPTION
Bump version 0.3.0 → 0.4.0 for the v0.4.0 release (public share pages + OG unfurls). Tag + GitHub release + announcement follow.